### PR TITLE
Add supported resource: aws_eks_node_group

### DIFF
--- a/docs/supported_resources.md
+++ b/docs/supported_resources.md
@@ -25,6 +25,7 @@ Support for the following is not currently included:
 | `aws_nat_gateway`          | |
 | `aws_rds_cluster_instance` | |
 | `aws_rds_cluster`          | |
+| `aws_eks_node_group`         | |
 
 ## The resource I want isn't supported
 


### PR DESCRIPTION
The position of the vertical line, is placed with two more spaces, because of considering #8 .