### PR TITLE
fix: include quotes in help text

### DIFF
--- a/blog/2021-01-11-terraform-cloud-costs-directly-from-pull-request-to-management.md
+++ b/blog/2021-01-11-terraform-cloud-costs-directly-from-pull-request-to-management.md
@@ -24,7 +24,7 @@ Example command:
 infracost --terraform-dir /path/to/module1 --format json > module1.json
 infracost --terraform-dir /path/to/module2 --format json > module2.json
 
-infracost report --format html module*.json > report.html
+infracost report --format html "module*.json" > report.html
 ```
 
 This is the output you'd get in HTML format. Notice that the filename and all tags are shown:

--- a/docs/guides/v0.8_migration.md
+++ b/docs/guides/v0.8_migration.md
@@ -47,7 +47,7 @@ The old root command will be fully removed in v0.9.0.
 
 The `infracost report` command has been deprecated and replaced with `infracost output`.
 
-This takes Infracost JSON files as inputs via `--path` and allows them to be combined and outputted in any format using `--format json|diff|table|html`. This command can be used with wildcards too, e.g. `infracost output --format html --path infracost*.json > output.html`.
+This takes Infracost JSON files as inputs via `--path` and allows them to be combined and outputted in any format using `--format json|diff|table|html`. This command can be used with wildcards too, e.g. `infracost output --format html --path "infracost*.json" > output.html`.
 
 ### Flags
 

--- a/docs/guides/v0.9_migration.md
+++ b/docs/guides/v0.9_migration.md
@@ -69,7 +69,7 @@ The deprecated root `infracost` command has been removed as we've moved to using
 
 The deprecated `infracost report` command has been removed and replaced with `infracost output`.
 
-This takes Infracost JSON files as inputs via `--path` and allows them to be combined and outputted in any format using `--format json|diff|table|html`. This command can be used with wildcards too, e.g. `infracost output --format html --path infracost*.json > output.html`. Run `infracost output --help` to see the other options.
+This takes Infracost JSON files as inputs via `--path` and allows them to be combined and outputted in any format using `--format json|diff|table|html`. This command can be used with wildcards too, e.g. `infracost output --format html --path "infracost*.json" > output.html`. Run `infracost output --help` to see the other options.
 
 #### Flags
 

--- a/docs/multi_project/report.md
+++ b/docs/multi_project/report.md
@@ -15,13 +15,13 @@ These reports can be uploaded to object storage such as AWS S3 or Google Cloud S
 
 Run `infracost output --help` to see the available options. Example usage:
 
-```shellell
+```shell
 infracost breakdown --path /path/to/project1 --format json > project1.json
 infracost breakdown --path /path/to/project2 --format json > project2.json
 
-infracost output --path project*.json --format html > report.html
+infracost output --path "project*.json" --format html > report.html
 
-infracost output --path project*.json --format diff
+infracost output --path "project*.json" --format diff
 ```
 
 ## Examples


### PR DESCRIPTION
Without this the glob pattern is expanded by shells so the CLI sees the first path as the flag value, followed by arguments (that are ignored)

Partly addresses #927