### PR TITLE
Change link color in TOC to default text color

### DIFF
--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -25,6 +25,7 @@
   --ifm-navbar-height: var(--navbar-height);
   --ifm-background-surface-color: var(--page-background-color);
   --ifm-toc-border-color: var(--docs-border-color);
+  --ifm-toc-link-color: var(--docs-text-color);
   --ifm-menu-color: var(--page-background-color);
   --ifm-menu-color-background-active: var(--emphasis-color);
   --ifm-menu-color-background-hover: var(--emphasis-color);


### PR DESCRIPTION
Previously the link color was white (ie. not readable) until the user
hovered over the menu item. This commit sets the link color to the
default text color which will make the heading readable even when not
hovered over.

Before:
![image](https://user-images.githubusercontent.com/5166002/132491478-41374a43-b053-40cf-a499-54ff74f3289f.png)
After:
![image](https://user-images.githubusercontent.com/5166002/132491505-2f9aac89-dcb7-4b2a-9592-b60ebe0ed711.png)
