### PR TITLE
doc: Rename terraform-json-file diff endpoint and breakdown endpoint

### DIFF
--- a/docs/integrations/infracost_api.md
+++ b/docs/integrations/infracost_api.md
@@ -12,13 +12,13 @@ The majority of users should use the [Infracost CLI](/docs/#quick-start), which 
 
 We plan to move and open source the API described in this page to the Cloud Pricing API, as it can be useful for CI/CD integrations such as [Atlantis](/docs/integrations/cicd#atlantis). In such cases, it might be easier to use `curl` or an HTTP library instead of installing the Infracost CLI. Terraform plan JSON files can be sent to this API, which runs `infracost` and returns the results. Whilst this API deletes files from the server after they are processed, it is a good security practice to remove secrets from the file before sending it to the API. For example, AWS provides [a grep command](https://gist.github.com/alikhajeh1/f2c3f607c44dabc70c73e04d47bb1307) that can be used to do this.
 
-To use this API, send an HTTP POST request to desired endpoint (e.g. https://pricing.api.infracost.io/terraform/diff) with the `terraform-json-file` parameter using the multipart/form-data request body format, as shown in the following example curl request. The `x-api-key` header must be set to your [Infracost API key](/docs/#2-get-api-key).
+To use this API, send an HTTP POST request to desired endpoint (e.g. https://pricing.api.infracost.io/diff) with a terraform plan json file sent in the `path` parameter using the multipart/form-data request body format, as shown in the following example curl request. The `x-api-key` header must be set to your [Infracost API key](/docs/#2-get-api-key).
 
 ## Breakdown
 
 Show full breakdown of costs
 
-https://pricing.api.infracost.io/terraform/breakdown
+https://pricing.api.infracost.io/breakdown
 
 | Header | Description | Notes |
 | ---       | ---         | ---   |
@@ -26,7 +26,7 @@ https://pricing.api.infracost.io/terraform/breakdown
 
 | Parameter | Description | Notes |
 | ---       | ---         | ---   |
-| terraform-json-file | Terraform plan JSON file | Required. Use '@' to upload the file with curl, e.g. `-F "terraform-json-file=@plan.json"` |
+| path | Terraform plan JSON file | Required. Use '@' to upload the file with curl, e.g. `-F "path=@plan.json"` |
 | usage-file | Infracost [usage file](/docs/usage_based_resources) that specifies values for usage-based resources | Not required. Use '@' to upload the file with curl, e.g. `-F "usage-file=@infracost-usage.yml"` |
 | show-skipped | Show unsupported resources, some of which might be free. | Not required. Defaults to false |
 | no-color | Turn off colored output, useful for CI/CD or Windows users (color output has a bug we need to fix on Windows) | Not required. Defaults to false |
@@ -50,8 +50,8 @@ values={[
   terraform show -json tfplan.binary > plan.json
 
   curl -X POST -H "x-api-key: my-api-key" -F "ci-platform=atlantis" \
-       -F "terraform-json-file=@plan.json" \
-       https://pricing.api.infracost.io/terraform/breakdown
+       -F "path=@plan.json" \
+       https://pricing.api.infracost.io/breakdown
   ```
 
   </TabItem>
@@ -86,7 +86,7 @@ values={[
 
 Show diff of monthly costs between current and planned state
 
-https://pricing.api.infracost.io/terraform/diff
+https://pricing.api.infracost.io/diff
 
 | Header | Description | Notes |
 | ---       | ---         | ---   |
@@ -94,7 +94,7 @@ https://pricing.api.infracost.io/terraform/diff
 
 | Parameter | Description | Notes |
 | ---       | ---         | ---   |
-| terraform-json-file | Terraform plan JSON file | Required. Use '@' to upload the file with curl, e.g. `-F "terraform-json-file=@plan.json"` |
+| path | Terraform plan JSON file | Required. Use '@' to upload the file with curl, e.g. `-F "path=@plan.json"` |
 | usage-file | Infracost [usage file](/docs/usage_based_resources) that specifies values for usage-based resources | Not required. Use '@' to upload the file with curl, e.g. `-F "usage-file=@infracost-usage.yml"` |
 | show-skipped | Show unsupported resources, some of which might be free. | Not required. Defaults to false |
 | no-color | Turn off colored output, useful for CI/CD or Windows users (color output has a bug we need to fix on Windows) | Not required. Defaults to false |
@@ -116,8 +116,8 @@ https://pricing.api.infracost.io/terraform/diff
   terraform show -json tfplan.binary > plan.json
 
   curl -X POST -H "x-api-key: my-api-key" -F "ci-platform=atlantis" \
-       -F "terraform-json-file=@plan.json" \
-       https://pricing.api.infracost.io/terraform/diff
+       -F "path=@plan.json" \
+       https://pricing.api.infracost.io/diff
   ```
 
   </TabItem>

--- a/docs/integrations/infracost_api.md
+++ b/docs/integrations/infracost_api.md
@@ -10,11 +10,87 @@ import TabItem from '@theme/TabItem';
 The majority of users should use the [Infracost CLI](/docs/#quick-start), which **does not** send the Terraform plan file to the Cloud Pricing API; instead it [sends](/docs/faq#what-data-is-sent-to-the-cloud-pricing-api) cost-related parameters, such as the instance type or disk size, so cloud prices can be found.
 :::
 
-We plan to move and open source the API described in this page to the Cloud Pricing API, as it can be useful for CI/CD integrations such as [Atlantis](/docs/integrations/cicd#atlantis). In such cases, it might be easier to use `curl` or an HTTP library instead of installing the Infracost CLI. Terraform plan JSON files can be sent to this API, which runs `infracost diff` and returns the results (`text/plain` response). Whilst this API deletes files from the server after they are processed, it is a good security practice to remove secrets from the file before sending it to the API. For example, AWS provides [a grep command](https://gist.github.com/alikhajeh1/f2c3f607c44dabc70c73e04d47bb1307) that can be used to do this.
+We plan to move and open source the API described in this page to the Cloud Pricing API, as it can be useful for CI/CD integrations such as [Atlantis](/docs/integrations/cicd#atlantis). In such cases, it might be easier to use `curl` or an HTTP library instead of installing the Infracost CLI. Terraform plan JSON files can be sent to this API, which runs `infracost` and returns the results. Whilst this API deletes files from the server after they are processed, it is a good security practice to remove secrets from the file before sending it to the API. For example, AWS provides [a grep command](https://gist.github.com/alikhajeh1/f2c3f607c44dabc70c73e04d47bb1307) that can be used to do this.
 
-## Usage
+To use this API, send an HTTP POST request to desired endpoint (e.g. https://pricing.api.infracost.io/terraform/diff) with the `terraform-json-file` parameter using the multipart/form-data request body format, as shown in the following example curl request. The `x-api-key` header must be set to your [Infracost API key](/docs/#2-get-api-key).
 
-To use this API, send an HTTP POST request to https://pricing.api.infracost.io/terraform-json-file with the `terraform-json-file` parameter using the multipart/form-data request body format, as shown in the following example curl request. The `x-api-key` header must be set to your [Infracost API key](/docs/#2-get-api-key).
+## Breakdown
+
+Show full breakdown of costs
+
+https://pricing.api.infracost.io/terraform/breakdown
+
+| Header | Description | Notes |
+| ---       | ---         | ---   |
+| `x-api-key` | Infracost API Key | Required.  Must be set to your [Infracost API key](/docs/#2-get-api-key). |
+
+| Parameter | Description | Notes |
+| ---       | ---         | ---   |
+| terraform-json-file | Terraform plan JSON file | Required. Use '@' to upload the file with curl, e.g. `-F "terraform-json-file=@plan.json"` |
+| usage-file | Infracost [usage file](/docs/usage_based_resources) that specifies values for usage-based resources | Not required. Use '@' to upload the file with curl, e.g. `-F "usage-file=@infracost-usage.yml"` |
+| show-skipped | Show unsupported resources, some of which might be free. | Not required. Defaults to false |
+| no-color | Turn off colored output, useful for CI/CD or Windows users (color output has a bug we need to fix on Windows) | Not required. Defaults to false |
+| format | Content type of the response | Not required.  Must be one of `table`, `html` or `json`.  Defaults to `table` |
+| fields | Fields to include in the response | Not required, supported by `table` and `html` formats.  Must be a comma separated list of fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.  Defaults to `monthlyQuantity,unit,monthlyCost` |
+
+### Examples
+
+<Tabs
+defaultValue="request"
+values={[
+{label: 'Example request', value: 'request'},
+{label: 'Response', value: 'response'},
+]}>
+<TabItem value="request">
+
+  ```shell
+  cd path/to/code
+  terraform init
+  terraform plan -out tfplan.binary
+  terraform show -json tfplan.binary > plan.json
+
+  curl -X POST -H "x-api-key: my-api-key" -F "ci-platform=atlantis" \
+       -F "terraform-json-file=@plan.json" \
+       https://pricing.api.infracost.io/terraform/breakdown
+  ```
+
+  </TabItem>
+  <TabItem value="response">
+
+  ```text
+  Project: examples/terraform
+  
+   Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                        
+   aws_instance.web_app                                                                                                 
+   ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+   ├─ root_block_device                                                                                                 
+   │  └─ Storage (general purpose SSD, gp2)                                50  GB                                 $5.00 
+   └─ ebs_block_device[0]                                                                                               
+      ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+      └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                        
+   aws_lambda_function.hello_world                                                                                      
+   ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+   └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                        
+   OVERALL TOTAL                                                                                                $742.64 
+  ----------------------------------
+  To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+  ```
+
+  </TabItem>
+</Tabs>
+
+## Diff 
+
+Show diff of monthly costs between current and planned state
+
+https://pricing.api.infracost.io/terraform/diff
+
+| Header | Description | Notes |
+| ---       | ---         | ---   |
+| `x-api-key` | Infracost API Key | Required.  Must be set to your [Infracost API key](/docs/#2-get-api-key). |
 
 | Parameter | Description | Notes |
 | ---       | ---         | ---   |
@@ -23,7 +99,7 @@ To use this API, send an HTTP POST request to https://pricing.api.infracost.io/t
 | show-skipped | Show unsupported resources, some of which might be free. | Not required. Defaults to false |
 | no-color | Turn off colored output, useful for CI/CD or Windows users (color output has a bug we need to fix on Windows) | Not required. Defaults to false |
 
-## Examples
+### Examples
 
 <Tabs
   defaultValue="request"
@@ -41,7 +117,7 @@ To use this API, send an HTTP POST request to https://pricing.api.infracost.io/t
 
   curl -X POST -H "x-api-key: my-api-key" -F "ci-platform=atlantis" \
        -F "terraform-json-file=@plan.json" \
-       https://pricing.api.infracost.io/terraform-json-file
+       https://pricing.api.infracost.io/terraform/diff
   ```
 
   </TabItem>

--- a/docs/integrations/infracost_api.md
+++ b/docs/integrations/infracost_api.md
@@ -12,13 +12,13 @@ The majority of users should use the [Infracost CLI](/docs/#quick-start), which 
 
 We plan to move and open source the API described in this page to the Cloud Pricing API, as it can be useful for CI/CD integrations such as [Atlantis](/docs/integrations/cicd#atlantis). In such cases, it might be easier to use `curl` or an HTTP library instead of installing the Infracost CLI. Terraform plan JSON files can be sent to this API, which runs `infracost` and returns the results. Whilst this API deletes files from the server after they are processed, it is a good security practice to remove secrets from the file before sending it to the API. For example, AWS provides [a grep command](https://gist.github.com/alikhajeh1/f2c3f607c44dabc70c73e04d47bb1307) that can be used to do this.
 
-To use this API, send an HTTP POST request to desired endpoint (e.g. https://pricing.api.infracost.io/diff) with a terraform plan json file sent in the `path` parameter using the multipart/form-data request body format, as shown in the following example curl request. The `x-api-key` header must be set to your [Infracost API key](/docs/#2-get-api-key).
+To use this API, send an HTTP POST request to desired endpoint (e.g. https://pricing.api.infracost.io/diff) with a Terraform plan JSON file sent in the `path` parameter using the multipart/form-data request body format, as shown in the following example curl request. The `x-api-key` header must be set to your [Infracost API key](/docs/#2-get-api-key).
 
 ## Breakdown
 
-Show full breakdown of costs
+Show full breakdown of costs.
 
-https://pricing.api.infracost.io/breakdown
+Send an HTTP POST to: https://pricing.api.infracost.io/breakdown
 
 | Header | Description | Notes |
 | ---       | ---         | ---   |
@@ -29,9 +29,9 @@ https://pricing.api.infracost.io/breakdown
 | path | Terraform plan JSON file | Required. Use '@' to upload the file with curl, e.g. `-F "path=@plan.json"` |
 | usage-file | Infracost [usage file](/docs/usage_based_resources) that specifies values for usage-based resources | Not required. Use '@' to upload the file with curl, e.g. `-F "usage-file=@infracost-usage.yml"` |
 | show-skipped | Show unsupported resources, some of which might be free. | Not required. Defaults to false |
-| no-color | Turn off colored output, useful for CI/CD or Windows users (color output has a bug we need to fix on Windows) | Not required. Defaults to false |
+| no-color | Turn off colored output, useful for CI/CD users | Not required. Defaults to false |
 | format | Content type of the response | Not required.  Must be one of `table`, `html` or `json`.  Defaults to `table` |
-| fields | Fields to include in the response | Not required, supported by `table` and `html` formats.  Must be a comma separated list of fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.  Defaults to `monthlyQuantity,unit,monthlyCost` |
+| fields | Fields to include in the response | Not required, supported by `table` and `html` formats.  Must be a comma separated list of fields: all, price, monthlyQuantity, unit, hourlyCost, monthlyCost.  Defaults to `monthlyQuantity,unit,monthlyCost` |
 
 ### Examples
 
@@ -84,9 +84,9 @@ values={[
 
 ## Diff 
 
-Show diff of monthly costs between current and planned state
+Show diff of monthly costs between current and planned state.
 
-https://pricing.api.infracost.io/diff
+Send an HTTP POST to: https://pricing.api.infracost.io/diff
 
 | Header | Description | Notes |
 | ---       | ---         | ---   |
@@ -97,7 +97,7 @@ https://pricing.api.infracost.io/diff
 | path | Terraform plan JSON file | Required. Use '@' to upload the file with curl, e.g. `-F "path=@plan.json"` |
 | usage-file | Infracost [usage file](/docs/usage_based_resources) that specifies values for usage-based resources | Not required. Use '@' to upload the file with curl, e.g. `-F "usage-file=@infracost-usage.yml"` |
 | show-skipped | Show unsupported resources, some of which might be free. | Not required. Defaults to false |
-| no-color | Turn off colored output, useful for CI/CD or Windows users (color output has a bug we need to fix on Windows) | Not required. Defaults to false |
+| no-color | Turn off colored output, useful for CI/CD users | Not required. Defaults to false |
 
 ### Examples
 


### PR DESCRIPTION
To add `breakdown` support to the terraform-plan-json API, I think we should rename the endpoints.  I was thinking we add `/terraform/diff` and `/terraform/breakdown`, and leave the `/terraform-json-file` around and undocumented for backwards compatibility.  What do you think?