### PR TITLE
Fix inline code background color

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,7 +69,7 @@ module.exports = {
     colorMode: {
       defaultMode: 'light',
       disableSwitch: true,
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
     },
     announcementBar: {
       id: 'support_us',


### PR DESCRIPTION
When the visitor of the blog or documentation has a the dark theme
enabled on their operating system the code blocks and inline code would
render with a dark text on a dark background color.

Disabling the docusaurus operating system theme detection fixes this.

Before:
![image](https://user-images.githubusercontent.com/5166002/144918078-52264779-e7c2-409b-abfa-e43a2ce7bbc6.png)

After: 
![image](https://user-images.githubusercontent.com/5166002/144918105-9a8c6ef8-90b2-4f54-a66a-fa35fffab24f.png)
