### PR TITLE
docs: add troubleshooting page

### DIFF
--- a/docs/cloud_pricing_api/self_hosted.md
+++ b/docs/cloud_pricing_api/self_hosted.md
@@ -5,7 +5,7 @@ title: Self-hosting
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Whilst most Infracost CLI users connect to our hosted Cloud Pricing API (since no cloud credentials or secrets are [sent](/docs/faq/#what-data-is-sent-to-the-cloud-pricing-api) to it), large enterprises that have restrictive security policies might require self-hosting. The following diagram shows an overview of the architecture.
+Whilst most Infracost CLI users connect to our hosted Cloud Pricing API (since [no cloud credentials or secrets are sent](/docs/faq/#what-data-is-sent-to-the-cloud-pricing-api) to it), large enterprises that have restrictive security policies might require self-hosting. The following diagram shows an overview of the architecture.
 
 ![Deployment overview](/img/docs/cloud_pricing_api/deployment_overview.png "Deployment overview")
 

--- a/docs/cloud_pricing_api/self_hosted.md
+++ b/docs/cloud_pricing_api/self_hosted.md
@@ -5,7 +5,7 @@ title: Self-hosting
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-The following diagram shows an overview of the architecture.
+Whilst most Infracost CLI users connect to our hosted Cloud Pricing API (since no cloud credentials or secrets are [sent](/docs/faq/#what-data-is-sent-to-the-cloud-pricing-api) to it), large enterprises that have restrictive security policies might require self-hosting. The following diagram shows an overview of the architecture.
 
 ![Deployment overview](/img/docs/cloud_pricing_api/deployment_overview.png "Deployment overview")
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,13 +7,13 @@ title: FAQ
 
 Infracost has a [CLI](https://github.com/infracost/infracost) and a [Cloud Pricing API](https://github.com/infracost/cloud-pricing-api) backend service, as well as many [CI/CD integrations](/docs/integrations/cicd).
 
-The CLI parses the Terraform plan JSON file to find [supported resources](/docs/supported_resources/overview) and uses [cost-related parameters](/docs/faq#example-request), such as the instance type or disk size, to find applicable cloud prices for that resource. The Cloud Pricing API [returns the prices](/docs/faq#example-response), which the CLI then uses to calculate the monthly costs. The results can be output in table, HTML or JSON format.
+The CLI parses the **Terraform plan JSON file** to find [supported resources](/docs/supported_resources/overview) and uses [cost-related parameters](/docs/faq#example-request), such as the instance type or disk size, to find applicable cloud prices for that resource. The CLI **does not** send the actual plan JSON file, or any cloud credentials or secrets to the Cloud Pricing API. The API [returns the prices](/docs/faq#example-response), which the CLI then uses to calculate the monthly costs. The results can be output in table, JSON format or [other formats](/docs/features/cli_commands/#combined-output-formats).
 
 ## Does Infracost need cloud credentials?
 
 That depends on how you run Infracost, since we run Terraform internally, which sometimes needs cloud credentials:
 - When Infracost is run against a [Terraform directory](/docs/#option-1-terraform-directory), Terraform will need access to cloud credentials, e.g. when running `terraform init` and `terraform plan`. These commands are only used to produce [plan JSON files](https://www.terraform.io/docs/commands/show.html#json-output) and no changes are made to your Terraform state or cloud resources.
-- When Infracost is run against a [Terraform plan JSON file](/docs/#option-2-terraform-plan-json), cloud credentials are not needed.
+- When Infracost is run against a [Terraform plan JSON file](/docs/#option-2-terraform-plan-json), cloud credentials are not needed since the CLI parses the plan JSON file directly.
 
 ## How does Infracost get cloud prices?
 
@@ -110,4 +110,4 @@ The environment variable `INFRACOST_CURRENCY` can be used to set the currency in
 
 ## Do you offer support?
 
-Yes! If you need help integrating Infracost in to your workflow, or want to talk about something else, please email [hello@infracost.io](mailto:hello@infracost.io). You can also join our [community Slack channel](https://www.infracost.io/community-chat) to chat with us.
+Yes! We're happy to help you, see our [support page](/docs/support).

--- a/docs/features/cli_commands.md
+++ b/docs/features/cli_commands.md
@@ -430,9 +430,3 @@ Run `infracost output --help` to see other options, such as `--fields` and `--sh
     <img src={useBaseUrl("img/screenshots/slack-message-format.png")} alt="Infracost Slack message report" />
   </TabItem>
 </Tabs>
-
-### Bulk run
-
-The following bash scripts run Infracost on all subfolders that have `.tf` files and output the combined results using the `infracost output` command. You can customize them based on which folders they should exclude or how you run Infracost (e.g. pass `--terraform-plan-flags`).
-  - to run `infracost breakdown`, use [breakdown_all.sh](https://github.com/infracost/infracost/blob/master/scripts/breakdown_all.sh)
-  - to run `infracost diff`, use [diff_all.sh](https://github.com/infracost/infracost/blob/master/scripts/breakdown_all.sh)

--- a/docs/features/config_file.md
+++ b/docs/features/config_file.md
@@ -62,7 +62,7 @@ Infracost configuration values are chosen in this order:
 
   projects:
     - path: examples/terraform
-      terraform_plan_flags: -var-file=prod.tfvars -var-file=us-east.tfvars 
+      terraform_plan_flags: -var-file=prod.tfvars -var-file=us-east.tfvars
       terraform_workspace: prod
       env:
         AWS_ACCESS_KEY_ID: ${PROD_AWS_ACCESS_KEY_ID}
@@ -107,35 +107,4 @@ Infracost configuration values are chosen in this order:
   </TabItem>
 </Tabs>
 
-If your requirements cannot be satisfied with a config file, please [create an issue](https://github.com/infracost/infracost/issues/new/choose) so we can understand the use-case. Also consider using the following bash script that demonstrate how Infracost commands can be combined.
-
-## Bulk run
-
-If using a config
-The following bash script runs Infracost on all subfolders that have `.tf` files and outputs the combined results using the [`infracost output`](/docs/features/cli_commands/#combined-output-formats) command. You can customize it based on which folders should be excluded or how you run Infracost (e.g. pass `--terraform-plan-flags`).
-
-```shell
-#!/usr/bin/env bash
-
-# Find all subfolders that have .tf files, but exclude "modules" folders, can be customized
-tfprojects=$(find . -type f -name '*.tf' | sed -E 's|/[^/]+$||' | grep -v modules | sort -u)
-
-# Run infracost on the folders individually
-while IFS= read -r tfproject; do
-  echo "Running infracost breakdown for $tfproject"
-  filename=$(echo $tfproject | sed 's:/:-:g' | cut -c3-)
-
-  # TODO: customize to how you run infracost, or run terraform first to generate a plan JSON file and pass that to --path
-  infracost breakdown --path $tfproject --format json --out-file "$filename-infracost-out.json"
-done <<< "$tfprojects"
-
-# Run infracost output to merge the subfolder results
-jsonfiles=($(find . -name "*-infracost-out.json" | tr '\n' ' '))
-infracost output --format diff $(echo ${jsonfiles[@]/#/--path })
-
-echo "Also saving the full breakdown in infracost-table.txt"
-infracost output --format table $(echo ${jsonfiles[@]/#/--path }) --out-file=infracost-table.txt
-
-# Remove temp json files
-rm $jsonfiles
-```
+If your requirements cannot be satisfied with a config file, please [create an issue](https://github.com/infracost/infracost/issues/new/choose) so we can understand the use-case. Also consider using [this bash script](/docs/troubleshooting/#multi-projects) that demonstrates how to generate plan JSON files for multiple projects and dynamically create a config file that can be used with Infracost.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -75,7 +75,7 @@ Assuming [Terraform](https://www.terraform.io/downloads.html) is already install
 </Tabs>
 
 ### 2. Get API key
-Register for a free API key, which is used by the CLI to query our Cloud Pricing API, e.g. get prices for instance types. No cloud credentials or secrets are [sent](/docs/faq/#what-data-is-sent-to-the-cloud-pricing-api) to the API and you can also self-host it.
+Register for a free API key, which is used by the CLI to query our Cloud Pricing API, e.g. get prices for instance types. No cloud credentials or secrets are [sent](/docs/faq/#what-data-is-sent-to-the-cloud-pricing-api) to the API and you can also [self-host](/docs/cloud_pricing_api/self_hosted/) it.
 ```shell
 infracost register
 ```
@@ -83,7 +83,7 @@ infracost register
 The key can be retrieved with `infracost configure get api_key`.
 
 ### 3. Run it
-Infracost does not make any changes to your Terraform state or cloud resources. Run Infracost using our example Terraform project to see how it works:
+Infracost does not make any changes to your Terraform state or cloud resources. Run Infracost using our example Terraform project to see how it works. The [CLI commands](/docs/features/cli_commands/) page describes the options for `--path`, which can point to a Terraform directory or plan JSON file.
 
 ```shell
 git clone https://github.com/infracost/example-terraform.git
@@ -111,7 +111,7 @@ Use our CI/CD integrations to add cost estimates to pull requests. This provides
 
 Other CI/CD systems can be supported using [our Docker images](/docs/integrations/cicd/#docker-images). If you run into any issues, please join our [community Slack channel](https://www.infracost.io/community-chat), we'd be happy to help!
 
-## Screenshots 
+### Screenshots
 
 Infracost running in pull requests:
 

--- a/docs/guides/terraform_modules.md
+++ b/docs/guides/terraform_modules.md
@@ -52,4 +52,4 @@ If you pass `--terraform-plan-flags='-var=enable_prod=true -var=enable_dev=true'
   PROJECT TOTAL                                                                    $983.96
 ```
 
-To show a cost breakdown for each module individually, one workaround at the moment is to run Infracost multiple times with different inputs. See the [`report_all.sh`](/docs/features/config_file/#bulk-run) bash script for an example of how to do this.
+To show a cost breakdown for each module individually, one workaround at the moment is to run Infracost multiple times with different inputs. See [this bash](/docs/features/config_file/#bulk-run) script for an example of how to do this.

--- a/docs/guides/terraform_modules.md
+++ b/docs/guides/terraform_modules.md
@@ -52,4 +52,4 @@ If you pass `--terraform-plan-flags='-var=enable_prod=true -var=enable_dev=true'
   PROJECT TOTAL                                                                    $983.96
 ```
 
-To show a cost breakdown for each module individually, one workaround at the moment is to run Infracost multiple times with different inputs. See [this bash](/docs/features/config_file/#bulk-run) script for an example of how to do this.
+To show a cost breakdown for each module individually, one workaround at the moment is to dynamically generate a [config file](/docs/features/config-file) using [this bash script](/docs/troubleshooting/#multi-projects) for an example of how to do this.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,122 @@
+---
+slug: troubleshooting
+title: Troubleshooting
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+Please try the following troubleshooting steps and if they don't help, either [create an issue](https://github.com/infracost/infracost/issues/new/choose) or join our [community Slack channel](https://www.infracost.io/community-chat) - we'll help you very quickly 😄🚀
+
+1. The Infracost CLI parses Terraform plan JSON files to estimate costs. If you're having trouble generating plan JSON files, see the relevant [Terraform CLI](#terraform-cli), [Terraform Cloud](#terraform-cloud) or [Terragrunt](#terragrunt) sections below.
+2. Use `ls -lah` in the CI build to check for any `.terraform*` files/folders that might be confusing Terraform running in CI vs previous runs that were used to create them. Removing those files might help.
+3. Check the Terraform version matches what you expect. Infracost works with Terraform v0.12 and above.
+4. If the Infracost CLI fails, re-run it with `--log-level=debug` or the `INFRACOST_LOG_LEVEL=debug` environment variable in case that provides helpful details.
+
+## Generating plan JSON files
+
+### Terraform CLI
+
+The Terraform CLI can be used to produce a plan JSON file as shown below:
+
+#### Single project
+
+```shell
+cd path/to/code
+terraform init
+# See https://www.terraform.io/language/values/variables#assigning-values-to-root-module-variables if your project needs variables
+terraform plan -out tfplan.binary
+terraform show -json tfplan.binary > plan.json
+
+infracost breakdown --path plan.json
+```
+
+#### Multi-projects/workspaces
+
+We recommend that you use an Infracost [config-file](/docs/features/config_file/) to define paths to the project/workspace plan JSON files. If that doesn't work for your use-case, use [this bash script](/docs/features/config_file/#bulk-run) to combine Infracost commands.
+
+### Terraform Cloud
+
+When Terraform Cloud's [remote execution mode](https://www.terraform.io/cloud-docs/workspaces/settings#execution-mode) is used, the Terraform CLI doesn't allow you to save the plan output directly. Thus the following bash script is needed to fetch the plan JSON from Terraform Cloud:
+
+```shell
+# If you're using Terraform Enterprise update this to your Terraform enterprise hostname (without https://)
+export TFC_HOST=app.terraform.io
+# Create a Team API Token or User API Token that can be used to fetch the plan, see https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html
+export TFC_TOKEN=my_token_here
+
+# This file is used by the Terraform CLI to authenticate with Terraform Cloud, it might also live in /root/.terraformrc on Linux CI/CD machines
+cp ~/.terraformrc ~/.terraformrc.old
+cat <<EOF > /root/.terraformrc
+credentials "$TFC_HOST" {
+  token = "$TFC_TOKEN"
+}
+EOF
+
+cd path/to/code
+terraform init
+
+# When using TFC remote execution, terraform doesn't allow us to save the plan output.
+# So we have to save the plan logs so we can parse out the run ID and fetch the plan JSON
+terraform plan -no-color | tee /tmp/plan_logs.txt
+
+# Parse the run URL and ID from the logs
+run_url=$(grep -A1 'To view this run' /tmp/plan_logs.txt | tail -n 1)
+run_id=$(basename $run_url)
+
+# Get the run plan response and parse out the path to the plan JSON
+run_plan_resp=$(wget -q -O - --header="Authorization: Bearer $TFC_TOKEN" "https://$TFC_HOST/api/v2/runs/$run_id/plan")
+plan_json_path=$(echo $run_plan_resp | sed 's/.*\"json-output\":\"\([^\"]*\)\".*/\1/')
+
+# Download the plan JSON
+wget -q -O plan.json --header="Authorization: Bearer $TFC_TOKEN" "https://$TFC_HOST$plan_json_path"
+
+infracost breakdown --path plan.json
+```
+
+### Terragrunt
+
+Terragrunt does not provide a quick way of creating a Terraform plan JSON file for the whole project, thus the following bash script is needed:
+
+```shell
+# This is path to the top-level terragrunt directory
+cd path/to/code
+
+# Generate plan JSON files for all Terragrunt modules and add them to an Infracost config file
+terragrunt run-all plan -out plan.cache
+
+# Find the plan files
+plans=($(find . -name plan.cache | tr '\n' ' '))
+
+# Generate plan JSON files by running terragrunt show for each plan file
+planjsons=()
+for plan in "${plans[@]}"; do
+  # Find the Terraform working directory for running terragrunt show
+  # We want to take the dir of the plan file and strip off anything after the .terraform-cache dir
+  # to find the location of the Terraform working directory that contains the Terraform code
+  dir=$(dirname $plan)
+  dir=$(echo "$dir" | sed 's/\(.*\)\/\.terragrunt-cache\/.*/\1/')
+
+  echo "Running terragrunt show for $(basename $plan) for $dir";
+  terragrunt show -json $(basename $plan) --terragrunt-working-dir=$dir --terragrunt-no-auto-init > $dir/plan.json
+  planjsons=(${planjsons[@]} "$dir/plan.json")
+done
+
+# Sort the plan JSONs so we get consistent project ordering in the config file
+IFS=$'\n' planjsons=($(sort <<<"${planjsons[*]}"))
+
+# Generate Infracost config file
+echo -e "version: 0.1\n\nprojects:\n" > infracost.yml
+for planjson in "${planjsons[@]}"; do
+  echo -e "  - path: $planjson" >> infracost.yml
+done
+
+infracost breakdown --config-file=infracost.yml
+```
+
+## Combining plan JSON files
+
+Once you have multiple Terraform plan JSON files, you can
+1. run [`infracost breakdown`](/docs/features/cli_commands/#breakdown-and-diff) with `--path plan-1.json --format json --out-file infracost-1.json` to generate an Infracost JSON file for each.
+2. run [`infracost output`](/docs/features/cli_commands/#combined-output-formats) with `--path "infracost-*.json" --format diff` (glob patterns need quotes) to combine the Infracost JSON files into one output format. The `infracost output --help` command shows the other options.
+
+These steps are used by our [CI/CD integrations](/docs/#4-add-to-cicd) to post pull request comments.

--- a/docs/integrations/cicd.md
+++ b/docs/integrations/cicd.md
@@ -44,15 +44,6 @@ All of the above CI/CD integrations support also posting the pull request commen
 
 <img src={useBaseUrl("img/screenshots/post_to_slack.png")} alt="Example Infracost diff output" />
 
-## CI/CD troubleshooting
-
-Please try the following steps and if that doesn't help, [create an issue](https://github.com/infracost/infracost/issues/new/choose) or join our [community Slack channel](https://www.infracost.io/community-chat) to chat with us.
-
-1. Set the [`INFRACOST_LOG_LEVEL`](/docs/integrations/environment_variables#infracost_log_level) environment variable to `debug` in case that provides more useful details. For Atlantis, also set [`atlantis_debug=true`](https://github.com/infracost/infracost-atlantis/#atlantis_debug).
-2. Check the Terraform version that Infracost is using matches the version you need. Use the [`INFRACOST_TERRAFORM_BINARY`](/docs/integrations/environment_variables/#infracost_terraform_binary) environment variable to change that.
-3. Use `ls -lah` in the CI build to check for any `.terraform*` files/folders that might be confusing Terraform running in CI vs previous runs that were used to create them. Removing those files might help.
-4. Check the [Terraform Cloud/Enterprise](/docs/integrations/terraform_cloud_enterprise) or [Terragrunt](/docs/features/terragrunt) docs pages if applicable.
-
 ## My CI/CD isn't supported
 
-Please [create an issue](https://github.com/infracost/infracost/issues/new/choose); we'll try to prioritize it depending on the community feedback. There is already a request for [BuildKite](https://github.com/infracost/infracost/issues/499) and [Codefresh](https://github.com/infracost/infracost/issues/975). Please 👍 it if you'd like us to work on them sooner. You can also join our [community Slack channel](https://www.infracost.io/community-chat) if you like to work on an integration, the existing GitHub Actions integration can act as a blueprint.
+Please [create an issue](https://github.com/infracost/infracost/issues/new/choose); we'll try to prioritize it depending on the community feedback. There is already a request for [BuildKite](https://github.com/infracost/infracost/issues/499) and [Codefresh](https://github.com/infracost/infracost/issues/975). Please 👍 it if you'd like us to work on them sooner. You can also join our [community Slack channel](https://www.infracost.io/community-chat) if you like to work on an integration, the existing GitLab CI integration can act as a blueprint.

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -5,4 +5,6 @@ title: GitLab CI
 
 See the [Infracost GitLab CI template](https://gitlab.com/infracost/infracost-gitlab-ci) for instructions and examples.
 
+If you used the [older setup](https://gitlab.com/infracost/infracost-gitlab-ci/-/blob/master/README-deprecated.md), please see our [migration guide](guides/gitlab_ci_migration.md).
+
 <img src="https://gitlab.com/infracost/infracost-gitlab-ci/-/raw/master/screenshot.png" width="550px" alt="Example Infracost diff output" />

--- a/docs/support.md
+++ b/docs/support.md
@@ -3,6 +3,8 @@ slug: support
 title: Support
 ---
 
-If you need help integrating Infracost in to your workflow, or want to talk about something else, please email [hello@infracost.io](mailto:hello@infracost.io). You can also join our [community Slack channel](https://www.infracost.io/community-chat) to chat with us.
+If you need help using Infracost, or want to talk about something else, please join our [community Slack channel](https://www.infracost.io/community-chat) to chat with us 😄 You can also email us at [hello@infracost.io](mailto:hello@infracost.io).
 
 If you notice a bug, please first [upgrade](/docs#installation) to the latest version of `infracost` to see if the bug has already been fixed. If not, [create an issue](https://github.com/infracost/infracost/issues/new/choose).
+
+You might find our [troubleshooting](/docs/guides/troubleshooting) guide helpful.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,29 +20,76 @@ The Terraform CLI can be used to produce a plan JSON file as shown below:
 
 #### Single project
 
-```shell
+```bash
 cd path/to/code
 terraform init
-# See https://www.terraform.io/language/values/variables#assigning-values-to-root-module-variables if your project needs variables
+
+# Customize this to how you run Terraform
+# e.g. if you are using variables you can pass them with -var or -var-file
 terraform plan -out tfplan.binary
 terraform show -json tfplan.binary > plan.json
 
 infracost breakdown --path plan.json
 ```
 
-#### Multi-projects/workspaces
+#### Multi-projects
 
-We recommend that you use an Infracost [config-file](/docs/features/config_file/) to define paths to the project/workspace plan JSON files. If that doesn't work for your use-case, use [this bash script](/docs/features/config_file/#bulk-run) to combine Infracost commands.
+We recommend that you use an Infracost [config file](/docs/features/config_file/) to define paths to the projects plan JSON files. If that doesn't work for your use-case, you can use the following bash script to generate Terraform plan JSON files, dynamically create a config file and pass it to Infracost.
+
+```bash
+# Path to Terraform code
+TF_ROOT=path/to/code
+
+cd $TF_ROOT
+
+# Find all subfolders that have .tf files, but exclude "modules" folders, can be customized
+tfprojects=($(find . -type f -name '*.tf' | sed -E 's|/[^/]+$||' | grep -v modules | sort -u))
+
+plans=()
+planjsons=()
+for project in "${tfprojects[@]}"; do
+  # You can remove this if Terraform is already init'd
+  echo "Running terraform init for $project"
+  terraform -chdir=$project init
+
+  # Customize this to how you run Terraform
+  # e.g. if you are using variables you can pass them with -var or -var-file
+  echo "Running terraform plan for $project"
+  terraform -chdir=$project plan -out tfplan.binary
+
+  echo "Running terraform show for $project"
+  terraform -chdir=$project show -json tfplan.binary > $project/plan.json
+
+  plans=(${plans[@]} "$project/tfplan.binary")
+  planjsons=(${planjsons[@]} "$project/plan.json")
+done
+
+# Generate Infracost config file
+echo -e "version: 0.1\n\nprojects:\n" > infracost-generated.yml
+for planjson in "${planjsons[@]}"; do
+  echo -e "  - path: $planjson" >> infracost-generated.yml
+done
+
+# Infracost CLI commands can be run now
+infracost breakdown --config-file=infracost-generated.yml
+
+# Cleanup generated files
+rm infracost-generated.yml
+rm $plans
+rm $planjsons
+```
 
 ### Terraform Cloud
 
 When Terraform Cloud's [remote execution mode](https://www.terraform.io/cloud-docs/workspaces/settings#execution-mode) is used, the Terraform CLI doesn't allow you to save the plan output directly. Thus the following bash script is needed to fetch the plan JSON from Terraform Cloud:
 
-```shell
+```bash
+# Path to Terraform code
+TF_ROOT=path/to/code
 # If you're using Terraform Enterprise update this to your Terraform enterprise hostname (without https://)
-export TFC_HOST=app.terraform.io
+TFC_HOST=app.terraform.io
 # Create a Team API Token or User API Token that can be used to fetch the plan, see https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html
-export TFC_TOKEN=my_token_here
+TFC_TOKEN=my_token_here
 
 # This file is used by the Terraform CLI to authenticate with Terraform Cloud, it might also live in /root/.terraformrc on Linux CI/CD machines
 cp ~/.terraformrc ~/.terraformrc.old
@@ -52,13 +99,18 @@ credentials "$TFC_HOST" {
 }
 EOF
 
-cd path/to/code
+cd $TF_ROOT
+
+# You can remove this if Terraform is already init'd
+echo "Running terraform init"
 terraform init
 
 # When using TFC remote execution, terraform doesn't allow us to save the plan output.
 # So we have to save the plan logs so we can parse out the run ID and fetch the plan JSON
+echo "Running terraform plan"
 terraform plan -no-color | tee /tmp/plan_logs.txt
 
+echo "Retrieving the plan JSON"
 # Parse the run URL and ID from the logs
 run_url=$(grep -A1 'To view this run' /tmp/plan_logs.txt | tail -n 1)
 run_id=$(basename $run_url)
@@ -70,22 +122,29 @@ plan_json_path=$(echo $run_plan_resp | sed 's/.*\"json-output\":\"\([^\"]*\)\".*
 # Download the plan JSON
 wget -q -O plan.json --header="Authorization: Bearer $TFC_TOKEN" "https://$TFC_HOST$plan_json_path"
 
+# Infracost CLI commands can be run now
 infracost breakdown --path plan.json
+
+# Cleanup generated files
+rm /tmp/plan_logs.txt
+rm plan.json
 ```
 
 ### Terragrunt
 
 Terragrunt does not provide a quick way of creating a Terraform plan JSON file for the whole project, thus the following bash script is needed:
 
-```shell
-# This is path to the top-level terragrunt directory
-cd path/to/code
+```bash
+# Path to Terraform code
+TF_ROOT=path/to/code
+
+cd $TF_ROOT
 
 # Generate plan JSON files for all Terragrunt modules and add them to an Infracost config file
-terragrunt run-all plan -out plan.cache
+terragrunt run-all plan -out tfplan.binary
 
 # Find the plan files
-plans=($(find . -name plan.cache | tr '\n' ' '))
+plans=($(find . -name tfplan.binary))
 
 # Generate plan JSON files by running terragrunt show for each plan file
 planjsons=()
@@ -96,7 +155,8 @@ for plan in "${plans[@]}"; do
   dir=$(dirname $plan)
   dir=$(echo "$dir" | sed 's/\(.*\)\/\.terragrunt-cache\/.*/\1/')
 
-  echo "Running terragrunt show for $(basename $plan) for $dir";
+  # Customize this to how you run Terragrunt
+  echo "Running terragrunt show for $(basename $plan) for $dir"
   terragrunt show -json $(basename $plan) --terragrunt-working-dir=$dir --terragrunt-no-auto-init > $dir/plan.json
   planjsons=(${planjsons[@]} "$dir/plan.json")
 done
@@ -105,12 +165,18 @@ done
 IFS=$'\n' planjsons=($(sort <<<"${planjsons[*]}"))
 
 # Generate Infracost config file
-echo -e "version: 0.1\n\nprojects:\n" > infracost.yml
+echo -e "version: 0.1\n\nprojects:\n" > infracost-generated.yml
 for planjson in "${planjsons[@]}"; do
-  echo -e "  - path: $planjson" >> infracost.yml
+  echo -e "  - path: $planjson" >> infracost-generated.yml
 done
 
-infracost breakdown --config-file=infracost.yml
+# Infracost CLI commands can be run now
+infracost breakdown --config-file=infracost-generated.yml
+
+# Cleanup generated files
+rm infracost-generated.yml
+rm $plans
+rm $planjsons
 ```
 
 ## Combining plan JSON files

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,12 +7,15 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Please try the following troubleshooting steps and if they don't help, either [create an issue](https://github.com/infracost/infracost/issues/new/choose) or join our [community Slack channel](https://www.infracost.io/community-chat) - we'll help you very quickly 😄🚀
 
-1. The Infracost CLI parses Terraform plan JSON files to estimate costs. If you're having trouble generating plan JSON files, see the relevant [Terraform CLI](#terraform-cli), [Terraform Cloud](#terraform-cloud) or [Terragrunt](#terragrunt) sections below.
-2. Use `ls -lah` in the CI build to check for any `.terraform*` files/folders that might be confusing Terraform running in CI vs previous runs that were used to create them. Removing those files might help.
-3. Check the Terraform version matches what you expect. Infracost works with Terraform v0.12 and above.
-4. If the Infracost CLI fails, re-run it with `--log-level=debug` or the `INFRACOST_LOG_LEVEL=debug` environment variable in case that provides helpful details.
+## 1. Enable additional logging
 
-## Generating plan JSON files
+If the Infracost CLI fails, re-run it with `--log-level=debug` or the `INFRACOST_LOG_LEVEL=debug` environment variable in case that provides helpful details.
+
+If the Terraform CLI fails, check their [debugging page](https://www.terraform.io/internals/debugging) for help. Likewise, if the Terragrunt CLI fails, check their [debugging page](https://terragrunt.gruntwork.io/docs/features/debugging/) for help.
+
+## 2. Generating plan JSON files
+
+The Infracost CLI parses Terraform plan JSON files to estimate costs. If you're having trouble generating plan JSON files, see the relevant [Terraform CLI](#terraform-cli), [Terraform Cloud](#terraform-cloud) or [Terragrunt](#terragrunt) sections below. These bash scripts can be modified and used in your CI/CD pipelines to generate Terraform plan JSON files.
 
 ### Terraform CLI
 
@@ -179,7 +182,12 @@ rm $plans
 rm $planjsons
 ```
 
-## Combining plan JSON files
+## 3. Check supported versions
+
+Check the Terraform version matches what you expect. Infracost works with Terraform v0.12 and above.
+Use `ls -lah` in the CI build to check for any `.terraform*` files/folders that might be confusing Terraform running in CI vs previous runs that were used to create them. Removing those files might help.
+
+## 4. Combining plan JSON files
 
 Once you have multiple Terraform plan JSON files, you can
 1. run [`infracost breakdown`](/docs/features/cli_commands/#breakdown-and-diff) with `--path plan-1.json --format json --out-file infracost-1.json` to generate an Infracost JSON file for each.

--- a/sidebars.js
+++ b/sidebars.js
@@ -56,6 +56,7 @@ module.exports = {
       label: 'Guides',
       collapsed: true,
       items: [
+        'guides/troubleshooting',
         'guides/actions_migration',
         'guides/gitlab_ci_migration',
         'guides/v0.8_migration',

--- a/sidebars.js
+++ b/sidebars.js
@@ -56,7 +56,6 @@ module.exports = {
       label: 'Guides',
       collapsed: true,
       items: [
-        'guides/troubleshooting',
         'guides/actions_migration',
         'guides/gitlab_ci_migration',
         'guides/v0.8_migration',
@@ -68,6 +67,10 @@ module.exports = {
     {
       type: 'doc',
       id: 'faq',
+    },
+    {
+      type: 'doc',
+      id: 'troubleshooting',
     },
   ]
 };


### PR DESCRIPTION
@aliscott only https://github.com/infracost/docs/commit/e4ac0d5d5a8997ef9de54ee7ba963813fdc6699d needs to be reviewed, I branched from master instead of 0.9.17

https://infracost.io/troubleshoot redirects to the new page. 

Related PR: https://github.com/infracost/infracost/pull/1282