### PR TITLE
fix: remove mention of compare-to in breakdown or output

### DIFF
--- a/docs/features/cli_commands.md
+++ b/docs/features/cli_commands.md
@@ -57,7 +57,7 @@ See the following example to generate an Infracost JSON file that represents the
   git checkout mybranch
 
   # Generate an Infracost JSON file that represents changes between the two runs (e.g. to store in CI or pass to `infracost comment`)
-  infracost breakdown --path . \
+  infracost diff --path . \
       --terraform-parse-hcl \
       --format json \
       --compare-to infracost-main.json \
@@ -738,15 +738,3 @@ Run `infracost output --help` to see other options, such as `--fields` and `--sh
     <img src={useBaseUrl("img/screenshots/slack-message-format.png")} alt="Infracost Slack message report" />
   </TabItem>
 </Tabs>
-
-## Compare Infracost runs
-
-The `infracost output` command can also be used to compare different Infracost runs. Assuming you generated `infracost-last-week.json` and `infracost-today.json` files using the `infracost breakdown --path /path/to/code --format json --out-file infracost.json` commands, you can compare the runs using the following command:
-
-```shell
-infracost output --path infracost-today.json \
-    --compare-to infracost-last-week.json \
-    --format diff
-```
-
-As a workaround to compare runs across different projects, edit the Infracost JSON files' `projects.name` manually so they match, and run the `infracost output` command as shown above.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -114,13 +114,13 @@ git clone https://github.com/infracost/example-terraform.git
 cd example-terraform/sample1
 
 # Generate JSON file from an Infracost run
-infracost breakdown --path . --terraform-parse-hcl --format json --out-file infracost-run.json
+infracost breakdown --path . --terraform-parse-hcl --format json --out-file infracost-base.json
 
 # Update the Terraform code by changing the instance type to m5.8xlarge
 vim main.tf
 
 # Show cost estimate diff
-infracost diff --path . --terraform-parse-hcl --compare-to infracost-run.json
+infracost diff --path . --terraform-parse-hcl --compare-to infracost-base.json
 ```
 
 :::tip
@@ -140,13 +140,13 @@ Infracost does not make any changes to your Terraform state or cloud resources. 
 cd path/to/my_terraform_project
 
 # Generate JSON file from an Infracost run
-infracost breakdown --path . --terraform-parse-hcl --format json --out-file infracost-run.json
+infracost breakdown --path . --terraform-parse-hcl --format json --out-file infracost-base.json
 
 # Make some changes to your Terraform project
 vim main.tf
 
 # Show cost estimate diff
-infracost diff --path . --terraform-parse-hcl --compare-to infracost-run.json
+infracost diff --path . --terraform-parse-hcl --compare-to infracost-base.json
 ```
 
 ### 5. Add to your CI/CD


### PR DESCRIPTION
Removes mention of `compare-to` in `breakdown` and `output` as per change https://github.com/infracost/infracost/pull/1620