### PR TITLE
docs: add note about private Terraform Registry modules

### DIFF
--- a/docs/features/terraform_modules.md
+++ b/docs/features/terraform_modules.md
@@ -30,7 +30,11 @@ projects:
 
 ### Terraform directory
 
-When Infracost is used with a [Terraform directory](/docs/features/cli_commands/#option-1-terraform-directory), usually no extra setup is needed for handling private modules since Infracost downloads these using the same method that Terraform does. That means the same version control credentials (e.g. SSH keys for Github) are used by Infracost to download private modules. You can follow [Terraform's docs](https://www.terraform.io/language/modules/sources) for more information.
+When Infracost is used with a [Terraform directory](/docs/features/cli_commands/#option-1-terraform-directory), the CLI supports Git modules and [Terraform Registry modules](https://www.terraform.io/language/modules/sources#terraform-registry).
+
+#### Git modules
+
+Usually no extra setup is needed for handling private git modules since Infracost downloads these using the same method that Terraform does. That means the same version control credentials (e.g. SSH keys for Github) are used by Infracost to download private modules. You can follow [Terraform's docs](https://www.terraform.io/language/modules/sources) for more information.
 
 In CI/CD integrations, you can an environment variable or secret with your private key so Infracost access private repositories (similar to how Terraform/Terragrunt does):
   ```shell
@@ -44,7 +48,11 @@ In CI/CD integrations, you can an environment variable or secret with your priva
   infracost breakdown --path /code
   ```
 
-HCL parsing does not work with modules that have a `source` in a private Terraform registry. Subscribe to [this issue](https://github.com/infracost/infracost/issues/1667) for updates.
+#### Terraform Registry modules
+
+You can follow either of the following steps so the Infracost CLI can download your private Terraform registry modules:
+1. In CI/CD integrations: set the `INFRACOST_TERRAFORM_CLOUD_TOKEN` environment variable to a [Team API Token or User API Token](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html). `INFRACOST_TERRAFORM_CLOUD_HOST` can also be set for Terraform Enterprise users (e.g. to avoid using app.terraform.io). These environment variables can also be set in the [config file](/docs/features/config_file).
+2. In local dev machines: set the [`TF_CLI_CONFIG_FILE`](https://www.terraform.io/docs/commands/environment-variables.html#tf_cli_config_file) to the absolute path of your Terraform CLI config file. This is more suitable for local dev machines.
 
 ### Terraform plan JSON
 

--- a/docs/features/terragrunt.md
+++ b/docs/features/terragrunt.md
@@ -16,10 +16,7 @@ infracost breakdown --path=. --exclude-path=dev --exclude-path=test
 
 ## Known issues
 
-The following known issues exist with Terragrunt and Infracost **v0.10**:
-
-1. If the CLI crashes when used with Terragrunt, please see [this GitHub issue](https://github.com/infracost/infracost/issues/1695) for a workaround.
-2. HCL parsing does not work with modules that have a `source` in a private Terraform registry. Comment on [this issue](https://github.com/infracost/infracost/issues/1667) if you need this.
+When using Terragrunt and Infracost **v0.10** or later: if the CLI crashes, please see [this GitHub issue](https://github.com/infracost/infracost/issues/1695) for a workaround.
 
 We'd like to fix these issues in upcoming releases. To unblock yourself until then, you can either:
 - Use the workaround in [this GitHub issue](https://github.com/infracost/infracost/issues/1695).

--- a/docs/guides/v0.10_migration.md
+++ b/docs/guides/v0.10_migration.md
@@ -106,8 +106,6 @@ infracost breakdown --path=. --exclude-path=dev --exclude-path=test
 
 There are [known issues](/docs/features/terragrunt/#known-issues) with Terragrunt, and some Terraform users. However, there are [workarounds](/docs/features/terragrunt/#known-issues) you can use to unblock yourself and continue to upgrade to v0.10.
 
-HCL parsing does not work with modules that have a `source` in a private Terraform registry. Comment on [this issue](https://github.com/infracost/infracost/issues/1667) if you need this.
-
 ## Migrations guides
 
 1. [**GitHub Actions**](/docs/guides/actions_migration/)


### PR DESCRIPTION
- [ ] If GitLab Registry Modules are [not supported](https://github.com/infracost/infracost/issues/1667#issuecomment-1170225694), add a note to the Terraform Registry modules section to mention this.