### PR TITLE
feat: add feedback redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,8 +2,10 @@ const path = require('path');
 const remarkExternalLinks = require('remark-external-links');
 
 let infracostDashboardApiEndpoint = 'https://dashboard.api-dev.infracost.io';
+let infracostDashboardEndpoint = 'https://dashboard.dev.infracost.io';
 if (process.env.NODE_ENV === 'production') {
   infracostDashboardApiEndpoint = 'https://dashboard.api.infracost.io';
+  infracostDashboardEndpoint = 'https://dashboard.infracost.io';
 }
 
 module.exports = {
@@ -18,6 +20,7 @@ module.exports = {
   projectName: 'docs',
   customFields: {
     infracostDashboardApiEndpoint,
+    infracostDashboardEndpoint,
   },
   plugins: [
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "prism-react-renderer": "^1.2.1",
         "react": "^16.8.4",
         "react-dom": "^16.8.4",
+        "react-helmet-async": "^1.3.0",
         "remark-external-links": "^8.0.0"
       }
     },
@@ -8168,6 +8169,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -10887,6 +10896,22 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "node_modules/react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -11882,6 +11907,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -19897,6 +19927,14 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -21768,6 +21806,18 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -22546,6 +22596,11 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prism-react-renderer": "^1.2.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
+    "react-helmet-async": "^1.3.0",
     "remark-external-links": "^8.0.0"
   },
   "browserslist": {

--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
 import LayoutProviders from '@theme/LayoutProviders';
 import LayoutHead from '@theme/LayoutHead';
 import AnnouncementBar from '@theme/AnnouncementBar';
@@ -6,23 +7,31 @@ import Navbar from '../components/Navbar';
 import CTA from '../components/CTA';
 import Footer from '../components/Footer';
 
-function PageLayout({ title, description, pageClass, children, hideCTA }) {
+function PageLayout({ title, description, pageClass, children, hideCTA, noIndex }) {
   return (
-    <LayoutProviders>
-      <LayoutHead
-        title={title}
-        description={description} />
+    <HelmetProvider>
+      <LayoutProviders>
+        <LayoutHead
+          title={title}
+          description={description} />
 
-      <AnnouncementBar />
+        {noIndex && (
+          <Helmet>
+            <meta name="robots" content="noindex" />
+          </Helmet>
+        )}
 
-      <div className={pageClass}>
-        <Navbar />
-        {children}
-      </div>
+        <AnnouncementBar />
 
-      {!hideCTA && (<CTA />)}
-      <Footer />
-    </LayoutProviders>
+        <div className={pageClass}>
+          <Navbar />
+          {children}
+        </div>
+
+        {!hideCTA && (<CTA />)}
+        <Footer />
+      </LayoutProviders>
+    </HelmetProvider>
   );
 }
 

--- a/src/pages/feedback/submit.js
+++ b/src/pages/feedback/submit.js
@@ -1,80 +1,23 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
-import useIsBrowser from '@docusaurus/useIsBrowser';
+import React, { useEffect } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import PageLayout from '../../components/PageLayout';
 
+// There's a redirect in Amplify for this, so this is just a backup incase that gets changed.
 function FeedbackSubmit() {
-  const isBrowser = useIsBrowser();
   const { siteConfig } = useDocusaurusContext();
-  const [submitSuccess, setSubmitSuccess] = useState(false);
-  const [submitError, setSubmitError] = useState(null);
-
-  const api = axios.create({
-    baseURL: siteConfig.customFields.infracostDashboardApiEndpoint,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  async function submitFeedback() {
-    setSubmitSuccess(false);
-    setSubmitError(null);
-
-    const urlParams = new URLSearchParams(window.location.search);
-    const value = urlParams.get('value');
-
-    try {
-      await api.post(`/event`, {
-        event: 'infracost-feedback-submit',
-        env: {
-          value,
-        }
-      });
-      setSubmitSuccess(true);
-    } catch(err) {
-      let msg = "Unknown error";
-      if (err.response && err.response.data && err.response.data.error) {
-        msg = err.response.data.error;
-      }
-      setSubmitError(msg);
-    }
-  }
 
   useEffect(() => {
-    if (isBrowser) {
-      submitFeedback();
-    }
-  }, [isBrowser]);
+    window.location.replace(`${siteConfig.customFields.infracostDashboardEndpoint}/feedback/redirect${window.location.search}`)
+  }, []);
 
   return (
     <PageLayout
         title="Feedback"
         description="Infracost is open source and free for the community."
         pageClass="feedback"
-        hideCTA={true}>
-
-      <div className="default-page-header">
-        <div className="container">
-          <div className="intro">
-            {submitSuccess && (
-              <>
-                <h1 className="tagline">Thank you!</h1>
-                <p className="sub-tagline">Your feedback has been submitted.</p>
-              </>
-            )}
-            {submitError && (
-              <>
-                <h1 className="tagline">Error submitting feedback!</h1>
-                <p className="sub-tagline">{submitError}</p>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-
-    </PageLayout>
-  );
+        hideCTA={true}
+        noIndex={true} />
+  )
 }
 
 export default FeedbackSubmit;


### PR DESCRIPTION
* Adds a frontend redirect for the old feedback page. This is a back-up until the amplify redirect is setup.
* Adds a `noIndex` param to the page layout so we can exclude pages from search index.