### PR TITLE
chore: fix pricing alignment on mobile

### DIFF
--- a/src/css/pricing.css
+++ b/src/css/pricing.css
@@ -113,6 +113,7 @@
 @media (max-width: 997px) {
 	.pricing .price__wrapper {
 		flex-direction: column;
+		align-items: flex-start;
 	}
 }
 
@@ -132,13 +133,15 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
+	justify-content: center;
 	font-weight: 1000;
 	color: var(--secondary-color);
 }
 
 @media (max-width: 997px) {
 	.pricing .price__suppl {
-		align-items: center;
+		align-items: flex-start;
+		justify-content: flex-start;
 	}
 }
 


### PR DESCRIPTION
Before:

![localhost_3000_pricing (1)](https://user-images.githubusercontent.com/5509711/211818832-0ef0288d-9b59-46f9-a7d4-8ae06142fcd0.png)

After:
![localhost_3000_pricing](https://user-images.githubusercontent.com/5509711/211818865-712297d0-5149-4b49-8ab0-6d95150c5e82.png)
