### PR TITLE
fix(ui): adds missing margin bottom to social media mentions

### DIFF
--- a/src/css/home.css
+++ b/src/css/home.css
@@ -272,6 +272,7 @@
   flex-wrap: nowrap;
   overflow-x: scroll;
   scrollbar-width: none;
+  margin-bottom: 3rem;
 }
 
 .social-mentions .cards::-webkit-scrollbar {


### PR DESCRIPTION
Spotted this one out in the wild 🐎

- fixes the missing gap between social media mentions and the "Download and try" CTA

Before:
![www infracost io_](https://user-images.githubusercontent.com/5509711/212037565-2a4f07c3-8a32-4683-977b-01b4d5c24f3a.png)

After:
![localhost_3000_](https://user-images.githubusercontent.com/5509711/212037593-b5b5677f-a8e1-4360-8f96-7b1512ce9fc3.png)
