### PR TITLE
docs: add `isDir` and `relPath`

### DIFF
--- a/docs/features/config_file.md
+++ b/docs/features/config_file.md
@@ -474,8 +474,8 @@ Returns true if the path exists within base.
 
   | name | description                                                                                                       | example                           |
   | ---- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-  | base | The directory to search for the given file or directory. Use `"."` to start from the project root.                | ".", "some/dir"                   |
-  | path | The path of the file or directory to search for. This must be relative to the base path provided at argument one. | "dir/to/find", "file/to/find.txt" |
+  | base | The directory to search for the given file or directory. Use `"."` to start from the project root.                | `"."`, `"some/dir"` |
+  | path | The path of the file or directory to search for. This must be relative to the base path provided at argument one. | `"dir/to/find"`, `"file/to/find.txt"` |
 
 ##### Example
 
@@ -534,7 +534,7 @@ Returns true if the path is a directory.
 
   | name | description       | example         |
   | ---- | ----------------- | --------------- |
-  | path | The path to check | ".", "some/dir" |
+  | path | The path to check | `"."`, `"some/dir"` |
 
 ##### Example
   <Tabs
@@ -595,8 +595,8 @@ This is useful for providing the correct relative path for shared variable files
 
   | name   | description                                                        | example         |
   | ------ | ------------------------------------------------------------------ | --------------- |
-  | base   | The base path that the resulting relative path is computed against | ".", "some/dir" |
-  | target | The target path, relative to the repo root directory               | "global.tfvars" |
+  | base   | The base path that the resulting relative path is computed against | `"."`, `"some/dir"` |
+  | target | The target path, relative to the repo root directory               | `"global.tfvars"` |
 
 ##### Example
   <Tabs

--- a/docs/guides/source_control_benefits.md
+++ b/docs/guides/source_control_benefits.md
@@ -17,7 +17,7 @@ Source control integrations ([GitHub App](/docs/integrations/github_app/) or [Gi
 
 ### 1. Required CLI version
 
-Currently, version 0.10.25+ of the Infracost CLI is needed for the Infracost Cloud features to work correctly.
+Currently, version 0.10.26+ of the Infracost CLI is needed for the Infracost Cloud features to work correctly.
 
 ### 2. Guardrails
 
@@ -31,7 +31,7 @@ To make the [Tagging policies](/docs/infracost_cloud/tagging_policies/) blocking
 
 ### 4. Branch details
 To show costs and tagging policy failures on default or base branches (e.g. master or main):
-  - In your CI/CD integration, on each default or base branch push, you should run these steps to run Infracost breakdown and upload the results:
+  - In your CI/CD integration, on each default or base branch push, you should run these steps to run Infracost breakdown and upload the results. If you do not need a [config file](/docs/features/config_file/), you can use `infracost breakdown --path=.` and point it to your repo root or Terraform directory.
   ```sh
   infracost breakdown --config-file=infracost.yaml \
     --format=json --out-file=/tmp/infracost.json

--- a/docs/infracost_cloud/tagging_policies.md
+++ b/docs/infracost_cloud/tagging_policies.md
@@ -15,6 +15,8 @@ Infracost enables you to define your tagging policies so you can communicate and
 
 You can create multiple tagging policies, for example one policy that applies to all resources, and another one that applies to certain resource types.
 
+Tagging policies check all AWS, Azure and Google Terraform resources that support tagging, including resources that Infracost does not show cost estimates for yet. Default tags that are applied as part of Terraform `provider` blocks are also checked by tagging policies.
+
 To create a tagging policy, log in to [Infracost Cloud](https://dashboard.infracost.io) and go to the Governance > Tagging policies page.
 
 ### 1. Scope of tagging policy

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,7 +120,7 @@ module.exports = {
     announcementBar: {
       id: 'support_us',
       content:
-        '<span class="announcement-message">We are hiring for Customer Success, <a target="_blank" rel="noopener noreferrer" href="https://infracost.io/join-the-team">apply here</a>!<img src="/img/icons/rocket-white.svg" class="icon-right" alt="Rocket icon" /></span>',
+        '<span class="announcement-message">If you like Infracost, give it a <a target="_blank" rel="noopener noreferrer" href="https://github.com/infracost/infracost">star on GitHub</a>!<img src="/img/icons/star-white.svg" class="star-right" alt="Star icon" /></span>',
       backgroundColor: '#2A2A5B',
       textColor: '#EBEBF2',
     },


### PR DESCRIPTION
I like the Template, Directory Tree, Output tabs, so I think we should make sure all examples have these as well.

This page is also getting to long, so maybe we should have a separate page for the Config File Reference which includes all the function definitions.