### PR TITLE
fix: tick colour

### DIFF
--- a/src/components/icons/Check.js
+++ b/src/components/icons/Check.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function Check({ color = 'fff', size = 24 }) {
+function Check({ color = '#db44b8', size = 24 }) {
   return (
     <svg
       enableBackground="new 0 0 {515.556 515.556}"


### PR DESCRIPTION
I forgot to add `#` to the the tick icon hex last time I did the refactor 🤦‍♂️

Before:
![Screenshot 2023-08-14 at 10 03 46](https://github.com/infracost/docs/assets/5509711/5881dc76-a244-438d-a412-b08bf6673803)

After:
![Screenshot 2023-08-14 at 11 35 09](https://github.com/infracost/docs/assets/5509711/03d6adc8-54da-4caf-95fc-0294bdcf4ad0)
