### PR TITLE
fix: add pre-wrap to pre

### DIFF
--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -88,6 +88,10 @@ div[class^=announcementBar_] {
   }
 }
 
+pre {
+  white-space: pre-wrap;
+}
+
 .DocSearch {
   --docsearch-text-color: var(--text-color);
   --docsearch-muted-color: var(--header-color);


### PR DESCRIPTION
`@theme/TabItem` doesn't handle the content correctly.

Before:
![Screenshot 2023-09-08 at 09 19 00](https://github.com/infracost/docs/assets/5509711/79f95e68-22aa-478b-bafb-633361ec08b5)

After:
![Screenshot 2023-09-08 at 09 21 20](https://github.com/infracost/docs/assets/5509711/dbdf12af-fbf3-4c40-a5bc-4cd2b0d3e5ce)


