### PR TITLE
fix: blog search URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -141,6 +141,7 @@ module.exports = {
       searchParameters: {
         facetFilters: [],
       },
+      externalUrlRegex: 'infracost\\.io/blog',
     },
   },
   presets: [


### PR DESCRIPTION
They were going to /docs/blog