### PR TITLE
docs: document new Terraform cloud variables

### DIFF
--- a/docs/features/config_file.md
+++ b/docs/features/config_file.md
@@ -301,6 +301,14 @@ The following table shows the parameters each `project` can have in the config f
   <td><code>terraform_workspace</code></td>
   <td>Optional. String. Used to set the Terraform workspace. Only set this for multi-workspace repos, otherwise it might result in the Terraform error "workspaces not supported".</td>
 </tr>
+<tr>
+  <td><code>terraform_cloud_workspace</code></td>
+  <td>Optional. String. For Terraform Enterprise users. Used to set the Terraform Cloud workspace. Only set this if your local workspace name differs from your cloud workspace, and you do not already have a Terraform cloud block defining the remote workspace name (e.g. using `prefix`).</td>
+</tr>
+<tr>
+  <td><code>terraform_cloud_org</code></td>
+  <td>Optional. String. For Terraform Enterprise users. Used to set the Terraform Cloud organization. Only set this if you do not already have a Terraform cloud block that defines your Terraform cloud organization name.</td>
+</tr>
 </table>
 
 ## Template syntax

--- a/docs/features/config_file.md
+++ b/docs/features/config_file.md
@@ -303,7 +303,7 @@ The following table shows the parameters each `project` can have in the config f
 </tr>
 <tr>
   <td><code>terraform_cloud_workspace</code></td>
-  <td>Optional. String. For Terraform Enterprise users. Used to set the Terraform Cloud workspace. Only set this if your local workspace name differs from your cloud workspace, and you do not already have a Terraform cloud block defining the remote workspace name (e.g. using `prefix`).</td>
+  <td>Optional. String. For Terraform Cloud/Enterprise users. Used to set the Terraform Cloud workspace. Only set this if your local workspace name differs from your cloud workspace, and you do not already have a Terraform Cloud block defining the remote workspace name (e.g. using `prefix`).</td>
 </tr>
 <tr>
   <td><code>terraform_cloud_org</code></td>

--- a/docs/features/config_file.md
+++ b/docs/features/config_file.md
@@ -307,7 +307,7 @@ The following table shows the parameters each `project` can have in the config f
 </tr>
 <tr>
   <td><code>terraform_cloud_org</code></td>
-  <td>Optional. String. For Terraform Enterprise users. Used to set the Terraform Cloud organization. Only set this if you do not already have a Terraform cloud block that defines your Terraform cloud organization name.</td>
+  <td>Optional. String. For Terraform Cloud/Enterprise users. Used to set the Terraform Cloud organization. Only set this if you do not already have a Terraform Cloud block that defines your Terraform cloud organization name.</td>
 </tr>
 </table>
 

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -56,7 +56,7 @@ For Terraform Enterprise users, used to override the default `app.terraform.io` 
 ### INFRACOST_TERRAFORM_CLOUD_WORKSPACE
 For Terraform Enterprise/Cloud users, used if your Terraform Cloud workspace name is different from the Terraform workspace name.
 
-Only use if Infracost cannot infer the workspace name from the Terraform cloud block configuration. If you have a valid Terraform cloud block, e.g:
+Only use if Infracost cannot infer the workspace name from the Terraform Cloud block configuration. If you have a valid Terraform Cloud block (shown below), use `INFRACOST_TERRAFORM_WORKSPACE` instead.
 
 ```hcl
 terraform {

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -70,7 +70,7 @@ terraform {
 ```
 
 ### INFRACOST_TERRAFORM_CLOUD_ORG
-For Terraform Enterprise users, used to specify the organization name. This is only needed if you do not have a valid Terraform cloud block configuration with an organization name.
+For Terraform Cloud/Enterprise users, used to specify the organization name. This is only needed if you do not have a valid Terraform Cloud block configuration with an organization name.
 
 ### INFRACOST_TERRAFORM_SOURCE_MAP
 

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -61,7 +61,7 @@ Only use if Infracost cannot infer the workspace name from the Terraform Cloud b
 ```hcl
 terraform {
 	cloud {
-		organization = "infracost"
+		organization = "acmeinc"
 		workspace {
 			prefix = "infracost-"
 		}

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -63,7 +63,7 @@ terraform {
 	cloud {
 		organization = "acmeinc"
 		workspace {
-			prefix = "infracost-"
+			prefix = "acme-"
 		}
 	}
 }

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -54,7 +54,7 @@ For Terraform Cloud/Enterprise users, set this to a [Team API Token or User API 
 For Terraform Enterprise users, used to override the default `app.terraform.io` backend host.
 
 ### INFRACOST_TERRAFORM_CLOUD_WORKSPACE
-For Terraform Enterprise users, used if you Terraform cloud workspace name is different from the Terraform workspace name.
+For Terraform Enterprise/Cloud users, used if your Terraform Cloud workspace name is different from the Terraform workspace name.
 
 Only use if Infracost cannot infer the workspace name from the Terraform cloud block configuration. If you have a valid Terraform cloud block, e.g:
 

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -53,6 +53,26 @@ For Terraform Cloud/Enterprise users, set this to a [Team API Token or User API 
 ### INFRACOST_TERRAFORM_CLOUD_HOST
 For Terraform Enterprise users, used to override the default `app.terraform.io` backend host.
 
+### INFRACOST_TERRAFORM_CLOUD_WORKSPACE
+For Terraform Enterprise users, used if you Terraform cloud workspace name is different from the Terraform workspace name.
+
+Only use if Infracost cannot infer the workspace name from the Terraform cloud block configuration. If you have a valid Terraform cloud block, e.g:
+
+```hcl
+terraform {
+	cloud {
+		organization = "infracost"
+		workspace {
+			prefix = "infracost-"
+		}
+	}
+}
+```
+Use `INFRACOST_TERRAFORM_WORKSPACE` instead.
+
+### INFRACOST_TERRAFORM_CLOUD_ORG
+For Terraform Enterprise users, used to specify the organization name. This is only needed if you do not have a valid Terraform cloud block configuration with an organization name.
+
 ### INFRACOST_TERRAFORM_SOURCE_MAP
 
 Accepts a comma separated list of `source=dest` pairs, and replaces any matched source URL value found in Terraform `module` or Terragrunt `terraform` blocks. This is useful when you have module URLs that are referenced in your infra-as-code repos one way (e.g. using a private URL), but they should use a different URL when Infracost runs them (e.g. using a public URL). See [this docs section](/docs/features/terraform_modules/#source-map) for more details.

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -68,7 +68,6 @@ terraform {
 	}
 }
 ```
-Use `INFRACOST_TERRAFORM_WORKSPACE` instead.
 
 ### INFRACOST_TERRAFORM_CLOUD_ORG
 For Terraform Enterprise users, used to specify the organization name. This is only needed if you do not have a valid Terraform cloud block configuration with an organization name.


### PR DESCRIPTION
Documents terraform cloud variables that are used to force cloud workspace and org. See https://github.com/infracost/infracost/pull/2993 for more details.