### PR TITLE
docs: clarify `volume_tags` behaviour

### DIFF
--- a/docs/infracost_cloud/tagging_policies.md
+++ b/docs/infracost_cloud/tagging_policies.md
@@ -83,6 +83,7 @@ Tagging policies check all AWS, Azure and Google Terraform resources that suppor
   - if `volume_tags` attribute is set it is checked. Otherwise,
   - if there is at least one `ebs_block_device` and no `*_block_device.tags` set, `volume_tags` are checked. Otherwise,
   - `.tags` for each `*_block_device` are checked.
+  - provider `default_tags` are automatically applied to `volume_tags` unless you are using an AWS provider version earlier than `5.39`.
 - For `aws_launch_template`, the `tag_specifications` attribute is also checked. If the `resource_type` is `instance` or `volume` these tags are then associated with either the `aws_instance` or `aws_autoscaling_group` resource that references the `aws_launch_template` and checked as part of those resources.
 - The following individual tag resources are not checked as these are used to tag resources defined outside of Terraform: `aws_autoscaling_group_tag`, `aws_ec2_tag`, `aws_transfer_tag`, `aws_ecs_tag`, `aws_dynamodb_tag`.
 


### PR DESCRIPTION
Adds a line to clarify the `volume_tags` functionality introduced in https://github.com/infracost/infracost/pull/3070