### PR TITLE
docs: modify the URL of 3rd party integration: Semaphore

### DIFF
--- a/docs/integrations/third_party_integrations.md
+++ b/docs/integrations/third_party_integrations.md
@@ -18,7 +18,7 @@ Infracost can be used in the following third-party systems. You should only cons
 - [Terrakube](https://docs.terrakube.io/user-guide/cost-estimation)
 - [Keptn](https://artifacthub.io/packages/keptn/keptn-integrations/infracost)
 - [Brainboard](https://docs.brainboard.co/ci-cd-engine/supported-plugins#cost-estimation)
-- [Semaphore](https://docs.semaphoreci.com/examples/estimating-cloud-costs-with-infracost/)
+- [Semaphore](https://docs.semaphoreci.com/using-semaphore/recipes/infracost)
 - [cloud-concierge](https://docs.cloudconcierge.io/how-it-works/pull-request-output#resource-cost-calculations)
 
 ## Creating an integration


### PR DESCRIPTION
This PR modifies the URL for the existing [Semaphore integration](https://www.infracost.io/docs/integrations/third_party_integrations/). At Semaphore, we've changed the docs engine to docusaurus and all the URLs changed. This PR fixes the single URL present in the Infracost docs.