### PR TITLE
Mdx upgrade compatibility

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -127,7 +127,7 @@ Infracost supports FinOps guardrails (budget checks, and kicking-off approval wo
 TFC does not provide these; it does enable you to write code to check for policies, but you will have to either teach FinOps practitioners and managers to code, and enable them to do it (there is no user interface), or have an engineering team do all that and maintain it. On top of these, Infracost provides an inventory of all resources that are failing tags and policies so you can see where your biggest issues are and how to fix them.
 
 #### 3. Infracost can be run on engineering machines
-Since Infracost does not need a Terraform plan file, cloud credentials or secrets, engineers can install the Infracost [VSCode Extension](/docs/integrations/vscode/) or the CLI and get cost estimates before sending pull requests, directly on their machines. Infracost also supports cost estimation of Terraform modules as well as Terragrunt projects. TFC cost estimation does not have these capabilities.
+Since Infracost does not need a Terraform plan file, cloud credentials or secrets, engineers can install the Infracost [VSCode Extension](/docs/features/vscode/) or the CLI and get cost estimates before sending pull requests, directly on their machines. Infracost also supports cost estimation of Terraform modules as well as Terragrunt projects. TFC cost estimation does not have these capabilities.
 
 ### What Terraform versions are supported?
 

--- a/docs/features/cli_commands.md
+++ b/docs/features/cli_commands.md
@@ -137,7 +137,7 @@ If the above method does not work for your use-case, you can use Terraform to ge
 
 The Infracost CLI can generate cost estimates in many formats: `json`, `diff`, `table`, `github-comment`, `gitlab-comment`, `azure-repos-comment`, `bitbucket-comment` and `slack-message`. To use them:
 
-1. Generate Infracost JSON output for each Terraform project and combine them into one file. This is the recommended way to store the snapshot of a cost estimate; it can be used by the CLI to generate other formats. The JSON format can also be used to setup [cost policies](/docs/features/cost_policies/).
+1. Generate Infracost JSON output for each Terraform project and combine them into one file. This is the recommended way to store the snapshot of a cost estimate; it can be used by the CLI to generate other formats. The JSON format can also be used to setup [cost policies](/docs/integrations/open_policy_agent).
   ```sh
   infracost breakdown --path dev --format json --out-file infracost-dev.json
   infracost breakdown --path prod --format json --out-file infracost-prod.json

--- a/docs/features/cli_commands.md
+++ b/docs/features/cli_commands.md
@@ -268,22 +268,24 @@ Run `infracost output --help` to see other options, such as `--fields` and `--sh
 
 The Infracost CLI can post cost estimates to pull request or commits on [GitHub](#github), [GitLab](#gitlab), [Azure Repos](#azure-repos) and [Bitbucket](#bitbucket), which is useful in CI/CD pipelines.
 
-<details><summary>Example commands to post a pull request comment</summary>
+<details>
+<summary>Example commands to post a pull request comment</summary>
 
-  ```shell
-  # Generate Infracost JSON baseline
-  git checkout main
-  infracost breakdown --config-file infracost.yml --format json \
-      --out-file infracost-base.json
+```shell
+# Generate Infracost JSON baseline
+git checkout main
+infracost breakdown --config-file infracost.yml --format json \
+    --out-file infracost-base.json
 
-  # Generate a diff by comparing the latest code change with the baseline
-  git checkout my-branch
-  infracost diff --config-file infracost.yml --format json \
-      --compare-to infracost-base.json --out-file infracost.json
+# Generate a diff by comparing the latest code change with the baseline
+git checkout my-branch
+infracost diff --config-file infracost.yml --format json \
+    --compare-to infracost-base.json --out-file infracost.json
 
-  # Post one comment with above Infracost JSON file
-  infracost comment github --path infracost.json ...
-  ```
+# Post one comment with above Infracost JSON file
+infracost comment github --path infracost.json ...
+```
+
 </details>
 
 The following `--behavior` options are supported when posting cost estimate comments:

--- a/docs/features/config_file.mdx
+++ b/docs/features/config_file.mdx
@@ -135,11 +135,12 @@ To use config files in your repos, follow these steps:
 
 When integrating Infracost with systems like GitHub or GitLab, we recommend the following order of precedence:
 
-1. **Infracost Cloud’s Org Settings > Default Repo Config File**: Set a default config file for all repos in your organization. This is useful if a lot of your repos have a similar structure since it applies globally, and individual repos can override it.
-  <img
-    src={useBaseUrl('img/infracost-cloud/default-repo-config-file.png')}
-    alt="Default config file used by all repos in the GitHub, Azure Repos or GitLab App integration"
-  />
+1. **Infracost Cloud's Org Settings > Default Repo Config File**: Set a default config file for all repos in your organization. This is useful if a lot of your repos have a similar structure since it applies globally, and individual repos can override it.
+
+   <img
+     src={useBaseUrl('img/infracost-cloud/default-repo-config-file.png')}
+     alt="Default config file used by all repos in the GitHub, Azure Repos or GitLab App integration"
+   />
 2. **Repo Settings in Infracost Cloud**: For specific repos, customize the config in the **Repo Settings** tab, which takes precedence over the default Org config.
 3. **`infracost.yml` or `infracost.yml.tmpl` in the repo root**: If needed, store a config file in the root of your repo. This file will be used only if there is no config set in Infracost Cloud, since the Cloud settings take precedence.
 
@@ -213,25 +214,27 @@ autodetect:
   <tbody>
     <tr>
       <td><code>env_names</code></td>
-      <td>Optional. Array of strings. Specifies environment names that should be used to group Terraform var files. Infracost uses these to detect and group projects by environments. For example:
-      <pre>
+      <td>
+        Optional. Array of strings. Specifies environment names that should be used to group Terraform var files. Infracost uses these to detect and group projects by environments. For example:
+        <pre>
 {`env_names:
   - dev
   - prod
   - staging`}
         </pre>
         These also support wildcards. For example, the following will detect <code>prod-us</code>, <code>prod-eu</code>, <code>dev-us</code> and <code>dev-eu</code> as separate environments:
-      <pre>
+        <pre>
 {`env_names:
   - "prod-*"
   - "dev-*"`}
         </pre>
-        </td>
+      </td>
     </tr>
     <tr>
       <td><code>exclude_dirs</code></td>
-      <td>Optional. Array of strings. A list of directories that should be excluded from project detection. Useful for ignoring outdated or test infrastructure. For example:
-      <pre>
+      <td>
+        Optional. Array of strings. A list of directories that should be excluded from project detection. Useful for ignoring outdated or test infrastructure. For example:
+        <pre>
 {`exclude_dirs:
   - legacy
   - tests`}
@@ -240,8 +243,9 @@ autodetect:
     </tr>
     <tr>
       <td><code>include_dirs</code></td>
-      <td>Optional. Array of strings. A list of directories that should be included in the project scan, ensuring these directories are detected. For example:
-      <pre>
+      <td>
+        Optional. Array of strings. A list of directories that should be included in the project scan, ensuring these directories are detected. For example:
+        <pre>
 {`include_dirs:
   - shared
   - ".infra/**"`}
@@ -250,8 +254,9 @@ autodetect:
     </tr>
     <tr>
       <td><code>path_overrides</code></td>
-      <td>Optional. Array of objects. Allows custom path overrides with rules to include or exclude specific combinations of environments and directories from project detection.
-      <pre>
+      <td>
+        Optional. Array of objects. Allows custom path overrides with rules to include or exclude specific combinations of environments and directories from project detection.
+        <pre>
 {`path_overrides:
   - path: "infra/base"
     only:
@@ -284,17 +289,20 @@ autodetect:
     </tr>
     <tr>
       <td><code>max_search_depth</code></td>
-      <td>Optional. Integer. Specifies the maximum directory depth to search for projects. Defaults to 10 if not provided.
+      <td>
+        Optional. Integer. Specifies the maximum directory depth to search for projects. Defaults to 10 if not provided.
       </td>
     </tr>
     <tr>
       <td><code>force_project_type</code></td>
-      <td>Optional. String. Forces the auto-detect function to classify all detected projects as a specific project type (either <code>terraform</code> or <code>terragrunt</code>). This is useful when auto-detect might conflict between the two types.
+      <td>
+        Optional. String. Forces the auto-detect function to classify all detected projects as a specific project type (either <code>terraform</code> or <code>terragrunt</code>). This is useful when auto-detect might conflict between the two types.
       </td>
     </tr>
     <tr>
       <td><code>terraform_var_file_extensions</code></td>
-      <td>Optional. String. A list of suffixes that should be used to recognise Terraform var files. This is useful when there are non-standard Terraform var file names which use different extensions.
+      <td>
+        Optional. String. A list of suffixes that should be used to recognise Terraform var files. This is useful when there are non-standard Terraform var file names which use different extensions.
       </td>
     </tr>
   </tbody>
@@ -331,33 +339,36 @@ projects:
     </tr>
     <tr>
       <td><code>terraform_var_files</code></td>
-      <td>Optional. Array of string. Variable files to use when parsing Terraform HCL code, similar to Terraform's <code>-var-file</code> flag. Files with the <code>.auto.tfvars</code> extension do not need to be added to the list as they are processed automatically by Infracost. The file paths are relative to the <code>path</code> of the project. For example:
-      <pre>
+      <td>
+        Optional. Array of string. Variable files to use when parsing Terraform HCL code, similar to Terraform's <code>-var-file</code> flag. Files with the <code>.auto.tfvars</code> extension do not need to be added to the list as they are processed automatically by Infracost. The file paths are relative to the <code>path</code> of the project. For example:
+        <pre>
 {`terraform_var_files:
   - global.tfvars
   - dev.tfvars`}
-      </pre>
+        </pre>
       </td>
     </tr>
     <tr>
       <td><code>terraform_vars</code></td>
-      <td>Optional. Map of strings. Input variables to use when parsing the Terraform HCL code, similar to Terraform's <code>-var</code> flag. For example:
-      <pre>
+      <td>
+        Optional. Map of strings. Input variables to use when parsing the Terraform HCL code, similar to Terraform's <code>-var</code> flag. For example:
+        <pre>
 {`terraform_vars:
   instance_count: 5
   artifact_version: foobar`}
-      </pre>
+        </pre>
       </td>
     </tr>
     <tr>
       <td><code>dependency_paths</code></td>
-      <td>Optional. <span style={{textDecoration: "underline"}}>Only applicable for GitHub, Azure Repos and GitLab App users</span>. Array of strings. Array of file or directory paths that should trigger project estimates. If this is specified, code changes to the <code>path</code> target will <b>NOT</b> trigger cost estimates unless the <code>path</code> is included in <code>dependency_paths</code>. All paths are relative to the working directory of your <code>infracost.yml</code> file. Supports glob patterns, for example:
-      <pre>
+      <td>
+        Optional. <span style={{textDecoration: "underline"}}>Only applicable for GitHub, Azure Repos and GitLab App users</span>. Array of strings. Array of file or directory paths that should trigger project estimates. If this is specified, code changes to the <code>path</code> target will <b>NOT</b> trigger cost estimates unless the <code>path</code> is included in <code>dependency_paths</code>. All paths are relative to the working directory of your <code>infracost.yml</code> file. Supports glob patterns, for example:
+        <pre>
 {`dependency_paths:
   - "config/**.json"
   - default.yml
   - "modules/**"`}
-      </pre>
+        </pre>
       </td>
     </tr>
     <tr>
@@ -366,13 +377,14 @@ projects:
     </tr>
     <tr>
       <td><code>exclude_paths</code></td>
-      <td>Optional. Array of strings. Array of directory paths to exclude from evaluation, relative to <code>path</code> of project. Supports glob patterns too, for example:
-      <pre>
+      <td>
+        Optional. Array of strings. Array of directory paths to exclude from evaluation, relative to <code>path</code> of project. Supports glob patterns too, for example:
+        <pre>
 {`exclude_paths:
   - projects/myproject
   - "app/*/ignore_dir"`}
-      </pre>
-    </td>
+        </pre>
+      </td>
     </tr>
     <tr>
       <td><code>include_all_paths</code></td>
@@ -384,12 +396,13 @@ projects:
     </tr>
     <tr>
       <td><code>env</code></td>
-      <td>Optional. Map of strings. Environment variables that are passed to the project during processing. Also supports referencing existing environment variables using the syntax <code>$&#123;MY_ENV_VAR&#125;</code>. Environment variables that start with <code>INFRACOST_</code> are global in scope (not per-project) and cannot be used inside this parameter. For example:
-      <pre>
+      <td>
+        Optional. Map of strings. Environment variables that are passed to the project during processing. Also supports referencing existing environment variables using the syntax <code>$&#123;MY_ENV_VAR&#125;</code>. Environment variables that start with <code>INFRACOST_</code> are global in scope (not per-project) and cannot be used inside this parameter. For example:
+        <pre>
 {`env:
   INSTANCE_TYPE: t3.large
   MY_ENV_KEY: $\{MY_SECRET_ENV_VAR\}`}
-      </pre>
+        </pre>
       </td>
     </tr>
     <tr>
@@ -1077,7 +1090,8 @@ Surrounds the string with single quotes.
 
 ### Examples
 
-<details><summary>Advanced config template replicating Infracost's auto-detect behavior</summary>
+<details>
+  <summary>Advanced config template replicating Infracost's auto-detect behavior</summary>
 
 This is useful if you want to use the Infracost auto-detect functionality but add additional config like `terraform_vars`.
 
@@ -1105,7 +1119,8 @@ projects:
 
 </details>
 
-<details><summary>Looping over projects with environments contained in a sub folder</summary>
+<details>
+  <summary>Looping over projects with environments contained in a sub folder</summary>
 
 ```yaml
 version: 0.1
@@ -1117,7 +1132,8 @@ projects:
 ```
 </details>
 
-<details><summary>Excluding certain projects</summary>
+<details>
+  <summary>Excluding certain projects</summary>
 
 ```yaml
 version: 0.1
@@ -1133,7 +1149,8 @@ projects:
 ```
 </details>
 
-<details><summary>Only matching certain project</summary>
+<details>
+  <summary>Only matching certain project</summary>
 
 ```yaml
 version: 0.1
@@ -1147,7 +1164,8 @@ projects:
 ```
 </details>
 
-<details><summary>Looping over multiple projects with a var file contained at the root level as well as project</summary>
+<details>
+  <summary>Looping over multiple projects with a var file contained at the root level as well as project</summary>
 
 ```yaml
 version: 0.1
@@ -1164,7 +1182,8 @@ projects:
 ```
 </details>
 
-<details><summary>Project with configuration defined in a non-Terraform file</summary>
+<details>
+  <summary>Project with configuration defined in a non-Terraform file</summary>
 
 ```yaml
 version: 0.1
@@ -1179,7 +1198,8 @@ projects:
 ```
 </details>
 
-<details><summary>Looping over projects with complex <code>matchPaths</code> matchers</summary>
+<details>
+  <summary>Looping over projects with complex <code>matchPaths</code> matchers</summary>
 
 Example folder structure:
 ```

--- a/docs/features/environment_variables.md
+++ b/docs/features/environment_variables.md
@@ -29,9 +29,9 @@ These examples show the output of the number `64145.4525` with different formatt
 
 | Enivornment variables                                                        | Output for 64145.4525 |
 |------------------------------------------------------------------------------|-----------------------|
-| INFRACOST_CURRENCY=USD<BR/>INFRACOST_CURRENCY_FORMAT="USD: 1.234,567890 $"   | `64.145,452500 $`     |
-| INFRACOST_CURRENCY=EUR<BR/>INFRACOST_CURRENCY_FORMAT="EUR: 1.234,56€"        | `64.145,45€`          |
-| INFRACOST_CURRENCY=GBP<BR/>INFRACOST_CURRENCY_FORMAT="GBP: £ 1,234.567"      | `£ 64,145.453`        |
+| INFRACOST_CURRENCY=USD<br/>INFRACOST_CURRENCY_FORMAT="USD: 1.234,567890 $"   | `64.145,452500 $`     |
+| INFRACOST_CURRENCY=EUR<br/>INFRACOST_CURRENCY_FORMAT="EUR: 1.234,56€"        | `64.145,45€`          |
+| INFRACOST_CURRENCY=GBP<br/>INFRACOST_CURRENCY_FORMAT="GBP: £ 1,234.567"      | `£ 64,145.453`        |
 
 ### INFRACOST_LOG_LEVEL
 Controls the log verbosity level. Can be set to `info` or `warn` in CI/CD systems to reduce noise, or `debug` to troubleshoot. Turns off spinners in output. Setting this environment variable is the same as using the `--log-level` flag.

--- a/docs/features/usage_based_resources.md
+++ b/docs/features/usage_based_resources.md
@@ -52,7 +52,8 @@ The `infracost-usage.yml` file lets engineers set usage values in their repos. T
 
 This `infracost-usage.yml` file does not currently support [project filters](/docs/features/usage_based_resources/#add-overrides). However, you can set values for specific resources. For example, you can set values for `aws_lambda_function.my_function` as opposed to the `aws_lambda_function` resource type that applies to all Lambda functions. This is useful when dealing with outlier resources that require customization.
 
-<details><summary>Customizing usage values for individual resources</summary>
+<details>
+<summary>Customizing usage values for individual resources</summary>
 
 The following `infracost-usage.yml` file demonstrates how values for individual resources can be customized:
 ```yml

--- a/docs/infracost_cloud/get_started.md
+++ b/docs/infracost_cloud/get_started.md
@@ -30,7 +30,8 @@ Test the integration using the following steps:
 1. In your infra-as-code repo, create a new branch "infracost_test".
 2. In the test branch, add a new file called `infracost_test.tf` at the repo root with the following example Terraform code.
 
-    <details><summary>Example AWS Terraform code</summary>
+   <details>
+   <summary>Example AWS Terraform code</summary>
 
     ```hcl
     provider "aws" {
@@ -76,7 +77,8 @@ Test the integration using the following steps:
 
     </details>
 
-    <details><summary>Example Azure Terraform code</summary>
+    <details>
+    <summary>Example Azure Terraform code</summary>
 
     ```hcl
     provider "azurerm" {
@@ -151,7 +153,8 @@ Test the integration using the following steps:
 
     </details>
 
-    <details><summary>Example Google Terraform code</summary>
+    <details>
+    <summary>Example Google Terraform code</summary>
 
     ```hcl
     provider "google" {

--- a/docs/infracost_cloud/key_concepts.md
+++ b/docs/infracost_cloud/key_concepts.md
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## Authentication
 
-Infracost Cloud supports logging in via [GitHub](/docs/faq/#can-i-log-in-with-github), Google, an email/password, or [enterprise SSO providers](/docs/infracost_cloud/sso/overview).
+Infracost Cloud supports logging in via [GitHub](/docs/faq/#can-i-log-in-with-github), Google, an email/password, or [enterprise SSO providers](/docs/infracost_cloud/sso).
 
 1. Go to [Infracost Cloud](https://dashboard.infracost.io) to sign up or log in.
 2. Switch to the desired organization. Every Infracost user has a default organization for personal use. You should create a new organization for your company using the organization dropdown at the top of the page.

--- a/docs/infracost_cloud/sso.md
+++ b/docs/infracost_cloud/sso.md
@@ -19,8 +19,7 @@ Assuming you have already purchased Infracost Cloud, you can setup SSO by follow
         <li>In the <a href="https://dashboard.infracost.io" target="_blank" rel="noopener noreferrer">Infracost Cloud
             dashboard</a> go to <code>Org Settings</code> and copy your <code>Org ID</code>. You will need to
           provide this to Infracost in a future step.</li>
-        <li>Login to the <a href="https://portal.azure.com" target="_blank" rel="noopener noreferrer">Azure portal</a>
-        </li>
+        <li>Login to the <a href="https://portal.azure.com" target="_blank" rel="noopener noreferrer">Azure portal</a></li>
         <li>Go to <code>Microsoft Entra ID &gt; Enterprise applications</code></li>
         <li>Click <code>New application</code></li>
         <li>Click <code>Create your own application</code></li>
@@ -46,7 +45,8 @@ Assuming you have already purchased Infracost Cloud, you can setup SSO by follow
         <li>Click <code>Create App Integration</code></li>
         <li>Select <code>SAML 2.0</code> and click Next.</li>
         <li>For the App name enter <code>Infracost Cloud</code> and click Next.</li>
-        <li>For Single sign on URL enter
+        <li>
+          For Single sign on URL enter
           <code>https://login.infracost.io/login/callback?connection=&lt;YOUR INFRACOST ORG ID&gt;</code>
         </li>
         <li>For the Audience URL (SP Entity ID) enter <code>urn:auth0:infracost:&lt;YOUR INFRACOST ORG ID&gt;</code><img
@@ -76,15 +76,13 @@ Assuming you have already purchased Infracost Cloud, you can setup SSO by follow
         <li>Copy the SSO URL and download the Certificate. You will need to supply these to Infracost in a future step.
           Click Continue.</li>
         <li>In the ACS URL enter:
-          <code>https://login.infracost.io/login/callback?connection=&lt;YOUR INFRACOST ORG ID&gt;</code>
-        </li>
+          <code>https://login.infracost.io/login/callback?connection=&lt;YOUR INFRACOST ORG ID&gt;</code></li>
         <li>In the Entity ID enter: <code>urn:auth0:infracost:&lt;YOUR INFRACOST ORG ID&gt;</code></li>
         <li>Tick <code>Signed response</code></li>
         <li>For Name ID format choose <code>UNSPECIFIED</code> and for Name ID choose
           <code>Basic Information &gt; Primary email</code>. The form should look like the following:<img loading="lazy"
             src="/docs/img/sso/google-workspace-service-provider.png" alt="Google Workspace Service Provider form"
-            class="img_ev3q" />
-        </li>
+            class="img_ev3q" /></li>
         <li>Click Continue</li>
         <li>Add the following Attributes and click Finish:<img loading="lazy"
             src="/docs/img/sso/google-workspace-attributes.png" alt="Google Workspace Service Provider form"

--- a/docs/infracost_cloud/tagging_policies.md
+++ b/docs/infracost_cloud/tagging_policies.md
@@ -73,7 +73,8 @@ Tagging policies check all AWS, Azure and Google Terraform resources that suppor
 - For Google Cloud resources, `label` keys and values are checked.
 - For tags set in modules, the actual module version being used is checked.
 
-<details><summary>AWS-specific notes</summary>
+<details>
+<summary>AWS-specific notes</summary>
 
 - For `aws_autoscaling_group`, if the `propagate_at_launch` attribute is not set to true, the resource fails tagging policies as resources launched from those Auto Scaling groups will not get the required tags.
 - For `aws_instance` with `ebs_block_device` or `root_block_device` definitions, tags for the attached volumes are checked as follows:
@@ -85,7 +86,8 @@ Tagging policies check all AWS, Azure and Google Terraform resources that suppor
 
 </details>
 
-<details><summary>Google-specific notes</summary>
+<details>
+<summary>Google-specific notes</summary>
 
 - For the following resources, `user_labels` are checked: `google_monitoring_alert_policy`, `google_monitoring_custom_service`, `google_monitoring_notification_channel`, `google_monitoring_service`, `google_sql_database_instance`, `google_monitoring_slo`.
 

--- a/docs/integrations/cicd.mdx
+++ b/docs/integrations/cicd.mdx
@@ -7,6 +7,23 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+export const CIBox = ({image, link, maxHeight, newWindow, text}) => (
+  <a
+    className="ci-box"
+    href={link}
+    >
+    <img
+      src={image}
+      target={newWindow ? "_blank" : null}
+      style={{
+        margin: "0 auto",
+        maxHeight: maxHeight ? maxHeight : "2rem"
+      }}
+      />
+      {text && (<div className="ci-subtitle">{text}</div>)}
+  </a>
+)
+
 export const Grid = ({logos}) => {
     const items = logos.map((e, i) => {
       return (<CIBox key={i} {...e}/>)
@@ -19,23 +36,6 @@ export const Grid = ({logos}) => {
       </div>
     )
 };
-
-export const CIBox = ({image, link, maxHeight, newWindow, text}) => (
-  <a
-    className="ci-box"
-    href={link}
-    >
-    <img
-      src={image}
-      target={newWindow ? "_blank" : null}
-      style={{
-        margin: "0 auto",
-        maxHeight: maxHeight ?? "2rem"
-      }}
-      />
-      {text && (<div className="ci-subtitle">{text}</div>)}
-  </a>
-)
 
 Use one of our many integrations so your engineering team can see cost estimates and FinOps best practices in pull requests **before making changes**. This provides your team with a safety net as people can discuss FinOps as part of the workflow.
 

--- a/docs/integrations/terraform_cloud_enterprise.md
+++ b/docs/integrations/terraform_cloud_enterprise.md
@@ -47,9 +47,10 @@ Follow the [instructions for configuring a Run Task](https://www.terraform.io/do
 - Enable the Run Task as a **post-plan stage** in your workspaces (only this "stage" option is supported by Infracost).
 - Set the Run Task to the **Mandatory** enforcement level so you can configure which Tagging or FinOps policies should block runs in Infracost Cloud.
 
-<details><summary>Example Terraform code to create a Run Task for your TFE organization</summary>
+<details>
+<summary>Example Terraform code to create a Run Task for your TFE organization</summary>
 
-  ```
+```
   # You can create Run Tasks for your TFE organization using the Terraform console
   # or inside your Terraform repository:
 


### PR DESCRIPTION
This is the first half of upgrading to the latest docusaurus (which will also quiet dependabot and very out of date dependencies).

This is the result of:

1. Make `npx docusaurus-mdx-checker -c docs` pass successfully (I chose not to add a github check for this because these compilation errors will be visible on npm run build check when docusaurus becomes 3.x)
2. Fix broken links

I've reviewed all the pages for no visual/content changes.